### PR TITLE
indeterminate state for checkbox.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,4 +12,4 @@ export {
 } from "./src/theme"
 export { DefaultTheme } from "./src/theme/default"
 export { devices } from "./src/media"
-export { Checkbox, CheckboxProps } from "./src/components/checkbox"
+export { Checkbox, CheckboxProps, useCheckboxesList } from "./src/components/checkbox"

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -1,7 +1,6 @@
 ## Checkbox component
 
-The implementation requires controlled behaviour, so the component requires to be wrapped
-and provided with state and handler.
+The implementation requires controlled behaviour, so the component has to be provided with state and handler.
 
 ### Props:
 
@@ -14,5 +13,57 @@ interface CheckboxProps {
   labelPosition?: "left" | "right"
   ref?: React.MutableRefObject<HTMLInputElement>
   className?: string
+  disabled?: boolean
+  indeterminate?: boolean
 }
+```
+
+### Typical usage:
+
+```JSX
+export const ContolledCheckbox = () => {
+  const [checked, setChecked] = useState(false)
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.currentTarget.checked)
+  }
+  return <Checkbox onChange={handleChange} checked={checked} />
+}
+```
+
+### Checkboxes List and indeterminate attribute
+
+Checkbox can have an `indeterminate` prop, if it represents the list of
+checkboxes that could be partially selected.
+
+For this purpose component exposes a hook `useCheckboxesList`:
+
+```JSX
+  const [checkedOne, setCheckedOne] = useState(false)
+  const [checkedTwo, setCheckedTwo] = useState(false)
+  const [checkedThree, setCheckedThree] = useState(false)
+
+  const valuesList = [checkedOne, checkedTwo, checkedThree]
+  const handlersList = [setCheckedOne, setCheckedTwo, setCheckedThree]
+
+  const [allChecked, indeterminate, switchAll] = useCheckboxesList(valuesList, handlersList)
+
+  ...
+
+  <PotentiallyIndeterminateCheckbox
+    label="All selected"
+    hecked={allChecked}
+    onChange={switchAll}
+    indeterminate={indeterminate}
+  />
+```
+
+Hook signature:
+
+```typescript
+type ChangeHandler = (checked: boolean) => void
+
+type UseCheckboxesList = (
+  values: boolean[],
+  handlers: Array<ChangeHandler>
+) => [boolean, boolean, () => void]
 ```

--- a/src/components/checkbox/checkbox.mock.tsx
+++ b/src/components/checkbox/checkbox.mock.tsx
@@ -1,5 +1,18 @@
 import React, { useState } from "react"
-import { Checkbox } from "."
+import styled from "styled-components"
+import { getGutterHeight } from "../../theme/utils"
+import { Checkbox, useCheckboxesList } from "."
+
+const MasterCheckbox = styled(Checkbox)`
+  margin-bottom: ${getGutterHeight};
+`
+
+const StyledCheckbox = styled(Checkbox)`
+  margin-left: 10px;
+  margin-bottom: ${getGutterHeight};
+`
+
+const CheckboxGroup = styled.div``
 
 export const MockedCheckbox = () => {
   const [checked, setChecked] = useState(false)
@@ -7,4 +20,45 @@ export const MockedCheckbox = () => {
     setChecked(e.currentTarget.checked)
   }
   return <Checkbox onChange={handleChange} checked={checked} />
+}
+
+export const MockedCheckboxList = () => {
+  const [checkedOne, setCheckedOne] = useState(false)
+  const [checkedTwo, setCheckedTwo] = useState(false)
+  const [checkedThree, setCheckedThree] = useState(false)
+
+  const valuesList = [checkedOne, checkedTwo, checkedThree]
+  const handlersList = [setCheckedOne, setCheckedTwo, setCheckedThree]
+
+  const [allChecked, indeterminate, switchAll] = useCheckboxesList(valuesList, handlersList)
+
+  const handleChange = (setter: any) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setter(e.currentTarget.checked)
+  }
+
+  return (
+    <CheckboxGroup>
+      <MasterCheckbox
+        label="The Boss checkbox"
+        checked={allChecked}
+        onChange={switchAll}
+        indeterminate={indeterminate}
+      />
+      <StyledCheckbox
+        label="Do you like greek salad?"
+        onChange={handleChange(setCheckedTwo)}
+        checked={checkedTwo}
+      />
+      <StyledCheckbox
+        label="Do you like sguschenka?"
+        onChange={handleChange(setCheckedOne)}
+        checked={checkedOne}
+      />
+      <StyledCheckbox
+        label="Was this story useful?"
+        onChange={handleChange(setCheckedThree)}
+        checked={checkedThree}
+      />
+    </CheckboxGroup>
+  )
 }

--- a/src/components/checkbox/checkbox.stories.tsx
+++ b/src/components/checkbox/checkbox.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import styled from "styled-components"
 import { storiesOf } from "@storybook/react"
 import { text, select, boolean } from "@storybook/addon-knobs"
-import { Checkbox } from "."
+import { Checkbox, useCheckboxesList } from "."
 import { getGutterHeight } from "../../theme/utils"
 import { readmeCleanup } from "../../../utils/readme"
 // @ts-ignore
@@ -73,7 +73,12 @@ checkBoxStory.add(
   subData
 )
 
+const MasterCheckbox = styled(Checkbox)`
+  margin-bottom: ${getGutterHeight};
+`
+
 const StyledCheckbox = styled(Checkbox)`
+  margin-left: 10px;
   margin-bottom: ${getGutterHeight};
 `
 
@@ -86,11 +91,23 @@ checkBoxStory.add(
     const [checkedTwo, setCheckedTwo] = useState(false)
     const [checkedThree, setCheckedThree] = useState(false)
 
+    const valuesList = [checkedOne, checkedTwo, checkedThree]
+    const handlersList = [setCheckedOne, setCheckedTwo, setCheckedThree]
+
+    const [allChecked, indeterminate, switchAll] = useCheckboxesList(valuesList, handlersList)
+
     const handleChange = (setter: any) => (e: React.ChangeEvent<HTMLInputElement>) => {
       setter(e.currentTarget.checked)
     }
+
     return (
       <CheckboxGroup>
+        <MasterCheckbox
+          label="The Boss checkbox"
+          checked={allChecked}
+          onChange={switchAll}
+          indeterminate={indeterminate}
+        />
         <StyledCheckbox
           label="Do you like greek salad?"
           onChange={handleChange(setCheckedTwo)}

--- a/src/components/checkbox/checkbox.test.tsx
+++ b/src/components/checkbox/checkbox.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/extend-expect"
 import { fireEvent } from "@testing-library/react"
 import { DefaultTheme } from "../../theme/default"
 import { testWrapper } from "../../../test-utils"
-import { MockedCheckbox } from "./checkbox.mock"
+import { MockedCheckbox, MockedCheckboxList } from "./checkbox.mock"
 
 describe("Checkbox test", () => {
   it(" * should render with required props", () => {
@@ -27,5 +27,14 @@ describe("Checkbox test", () => {
     fireEvent.click(checkbox)
     fireEvent.click(checkbox)
     expect(checkbox.checked).toBe(false)
+  })
+
+  it(" * should support indeterminate state for checkboxes list", () => {
+    const { container } = testWrapper<null>(MockedCheckboxList, null, DefaultTheme, null)
+    const checkboxesList = container.querySelectorAll("input")
+    const mainCheckbox = checkboxesList[0]
+    const childCheckbox = checkboxesList[1]
+    fireEvent.click(childCheckbox)
+    expect(mainCheckbox.indeterminate).toBe(true)
   })
 })

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef } from "react"
 
 import {
   CheckboxContainer,
@@ -19,6 +19,7 @@ export interface CheckboxProps {
   ref?: React.MutableRefObject<HTMLInputElement>
   className?: string
   disabled?: boolean
+  indeterminate?: boolean
 }
 
 export const Checkbox = ({
@@ -27,16 +28,34 @@ export const Checkbox = ({
   className,
   labelPosition,
   label,
+  indeterminate,
+  ref,
   ...props
 }: CheckboxProps) => {
+  const preparedRef = useRef(null)
+  const checkboxInput = ref || preparedRef
+
+  if (checkboxInput.current) {
+    checkboxInput.current.indeterminate = Boolean(indeterminate)
+  }
+
   return (
     <StyledLabel className={className}>
       <AccessibleArea />
       {label && labelPosition === "left" && <LabelText left>{label}</LabelText>}
       <CheckboxContainer>
-        <HiddenCheckboxInput disabled={disabled} checked={checked} {...props} />
-        <StyledCheckbox checked={checked} disabled={disabled}>
-          <StyledIcon name="checkmark_s" disabled={disabled} />
+        <HiddenCheckboxInput
+          disabled={disabled}
+          checked={checked}
+          indeterminate={indeterminate}
+          ref={checkboxInput}
+          {...props}
+        />
+        <StyledCheckbox indeterminate={indeterminate} checked={checked} disabled={disabled}>
+          <StyledIcon
+            name={indeterminate ? "checkmark_partial_s" : "checkmark_s"}
+            disabled={disabled}
+          />
         </StyledCheckbox>
       </CheckboxContainer>
       {label && labelPosition === "right" && <LabelText right>{label}</LabelText>}

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -44,13 +44,7 @@ export const Checkbox = ({
       <AccessibleArea />
       {label && labelPosition === "left" && <LabelText left>{label}</LabelText>}
       <CheckboxContainer>
-        <HiddenCheckboxInput
-          disabled={disabled}
-          checked={checked}
-          indeterminate={indeterminate}
-          ref={checkboxInput}
-          {...props}
-        />
+        <HiddenCheckboxInput disabled={disabled} checked={checked} ref={checkboxInput} {...props} />
         <StyledCheckbox indeterminate={indeterminate} checked={checked} disabled={disabled}>
           <StyledIcon
             name={indeterminate ? "checkmark_partial_s" : "checkmark_s"}

--- a/src/components/checkbox/hooks.ts
+++ b/src/components/checkbox/hooks.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react"
+
+type ChangeHandler = (checked: boolean) => void
+
+type UseCheckboxesList = (
+  values: boolean[],
+  handlers: Array<ChangeHandler>
+) => [boolean, boolean, () => void]
+
+export const useCheckboxesList: UseCheckboxesList = (
+  values: boolean[],
+  handlers: Array<ChangeHandler>
+) => {
+  const checked = values.every(isChecked => isChecked)
+  const isIndeterminate = !checked && values.includes(false) && values.includes(true)
+
+  const switchAllCheckboxes = useCallback(() => {
+    if (checked) {
+      handlers.forEach(handler => handler(false))
+    } else {
+      handlers.forEach(handler => handler(true))
+    }
+  }, [checked, handlers])
+
+  return [checked, isIndeterminate, switchAllCheckboxes]
+}

--- a/src/components/checkbox/index.ts
+++ b/src/components/checkbox/index.ts
@@ -1,1 +1,2 @@
 export { Checkbox, CheckboxProps } from "./checkbox"
+export { useCheckboxesList } from "./hooks"

--- a/src/components/checkbox/styled.tsx
+++ b/src/components/checkbox/styled.tsx
@@ -16,7 +16,12 @@ export const StyledIcon = styled(Icon)<{ disabled?: boolean }>`
     disabled ? getColor(["gray", "silverSand"]) : getColor(["green", "greenHaze"])};
 `
 
-export const HiddenCheckboxInput = styled.input.attrs({ type: "checkbox" })`
+export const HiddenCheckboxInput = styled.input.attrs(
+  ({ indeterminate }: { indeterminate?: boolean }) => ({
+    type: "checkbox",
+    indeterminate: Boolean(indeterminate),
+  })
+)`
   border: 0;
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
@@ -29,7 +34,11 @@ export const HiddenCheckboxInput = styled.input.attrs({ type: "checkbox" })`
   width: 1px;
 `
 
-export const StyledCheckbox = styled.div<{ checked: boolean; disabled?: boolean }>`
+export const StyledCheckbox = styled.div<{
+  checked: boolean
+  disabled?: boolean
+  indeterminate?: boolean
+}>`
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -48,7 +57,10 @@ export const StyledCheckbox = styled.div<{ checked: boolean; disabled?: boolean 
   }
 
   ${StyledIcon} {
-    visibility: ${props => (props.checked ? "visible" : "hidden")};
+    visibility: ${props => {
+      if (props.indeterminate) return "visible"
+      return props.checked ? "visible" : "hidden"
+    }};
   }
 `
 

--- a/src/components/checkbox/styled.tsx
+++ b/src/components/checkbox/styled.tsx
@@ -16,12 +16,9 @@ export const StyledIcon = styled(Icon)<{ disabled?: boolean }>`
     disabled ? getColor(["gray", "silverSand"]) : getColor(["green", "greenHaze"])};
 `
 
-export const HiddenCheckboxInput = styled.input.attrs(
-  ({ indeterminate }: { indeterminate?: boolean }) => ({
-    type: "checkbox",
-    indeterminate: Boolean(indeterminate),
-  })
-)`
+export const HiddenCheckboxInput = styled.input.attrs({
+  type: "checkbox",
+})`
   border: 0;
   clip: rect(0 0 0 0);
   clip-path: inset(50%);


### PR DESCRIPTION
As @oyabun requested, I made and indeterminate controlled state of a checkbox, for the case when we have checkbox representing the aggregated state of some list.
There is a small hook exposed to work with this case.