### PR TITLE
changed instantFeedback logic, added isDirty flag

### DIFF
--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -32,6 +32,7 @@ export interface ComponentProps {
   error?: boolean | string
   success?: boolean | string
   touched?: boolean
+  isDirty?: boolean
   instantFeedback?: boolean
   className?: string
   fieldIndicator?: string | ReactNode
@@ -47,6 +48,7 @@ Notable props:
 - `fieldMessage` - default message under the input field
 - `success` and `error` - status indicators, could be boolean or strings (in this case they render instead of `fieldMessage`)
 - `instantFeedback` - set this to true, if you want to provide validation status as user types, not onBlur/other.
+- `isDirty` - boolean flag showing if something was ever entered into the input. Use together with instantFeedback.
 - `metaShrinked` - set this to true to not render any meta information and reserved space under the input field
 - `fieldIndicator` - additional information field, which could be used for displaying `maxChars` string or other meta info.
 
@@ -93,6 +95,7 @@ TBD if we will use it, or procees with custom event-oriented form touch.
 ```typescript
 type InputValue = string
 type MaxCharsIndicator = string
+type IsDirty = boolean
 type UseInputValue = ({
   value,
   onChange,
@@ -101,12 +104,12 @@ type UseInputValue = ({
   value?: string
   onChange?: ChangeEventHandler
   maxChars?: number
-}) => [InputValue, ChangeEventHandler, MaxCharsIndicator]
+}) => [InputValue, ChangeEventHandler, MaxCharsIndicator, IsDirty]
 ```
 
 `useInputValue` hook is a short way to add basic functionaluty to the `<TextInput />` - a controlled state for
 input value, and custom side-effects handling for onChange. If `maxChars` option is passed, it will also return
-a quantity of entered symbols in relation to maximum allowed `as string`.
+a quantity of entered symbols in relation to maximum allowed `as string`. `isDirty` flag indicates if value was changed at least once, required for `instantFeedback` inputs to work properly.
 
 ### Further improvements TBD
 

--- a/src/components/input/input.stories.tsx
+++ b/src/components/input/input.stories.tsx
@@ -77,6 +77,64 @@ inputStory.add(
   subData
 )
 
+inputStory.add(
+  "Input with instant feedback",
+  () => {
+    const disabled = boolean("Disabled", false)
+    const [isValid, setIsValid] = useState(false)
+    const [validationMessage, setValidationMessage] = useState("")
+    const fieldMessage = text(
+      "Defailt field message",
+      "Pls fill this field for the sake of humanity"
+    )
+    const charLimit = number("Max characters", 20)
+
+    const onChange = useCallback(() => {
+      console.log("value has changed")
+    }, [])
+
+    const [value, handleChange, charsIndicator, isDirty] = useInputValue({
+      onChange,
+      maxChars: charLimit,
+    })
+
+    const onBlur = useCallback(() => {
+      console.log("performing some side effect on blur")
+    }, [])
+
+    const [touched, blurHandler] = useTouchedState({ onBlur })
+
+    useEffect(() => {
+      if (!isValid && value.length > 0) {
+        setIsValid(true)
+        setValidationMessage("Very green, much validated")
+      } else if (isValid && value.length === 0) {
+        setIsValid(false)
+      }
+    }, [isValid, value.length, touched])
+
+    return (
+      <Container>
+        <TextInput
+          disabled={disabled}
+          placeholder={text("Placeholder", "Enter something")}
+          fieldMessage={fieldMessage}
+          fieldIndicator={charsIndicator}
+          value={value}
+          touched={touched}
+          onBlur={blurHandler}
+          onChange={handleChange}
+          success={isValid && validationMessage}
+          error={!isValid}
+          instantFeedback
+          isDirty={isDirty}
+        />
+      </Container>
+    )
+  },
+  subData
+)
+
 const StyledIcon = styled(Icon)`
   fill: ${getColor(["gray", "limedSpruce"])};
 `

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -32,6 +32,7 @@ export interface ComponentProps {
   error?: boolean | string
   success?: boolean | string
   touched?: boolean
+  isDirty?: boolean
   instantFeedback?: boolean
   className?: string
   fieldIndicator?: string | ReactNode
@@ -58,11 +59,12 @@ export const TextInput = ({
   metaShrinked,
   placeholder = "",
   label,
+  isDirty,
   ...props
 }: TextInputProps) => {
   const [focused, handleFocus, handleBlur] = useFocusedState({ onBlur, onFocus })
 
-  const metaDisplayed = touched || instantFeedback
+  const metaDisplayed = touched || (instantFeedback && isDirty)
   const isSuccess = metaDisplayed && success
   const isError = metaDisplayed && error
   const errorMessage = isError && error !== true && error

--- a/src/components/input/use-input-value.tsx
+++ b/src/components/input/use-input-value.tsx
@@ -3,6 +3,7 @@ import { ChangeEventHandler, ReactInputChangeEvent } from "./types"
 
 type InputValue = string
 type MaxCharsIndicator = string
+type IsDirty = boolean
 type UseInputValue = ({
   value,
   onChange,
@@ -11,10 +12,11 @@ type UseInputValue = ({
   value?: string
   onChange?: ChangeEventHandler
   maxChars?: number
-}) => [InputValue, ChangeEventHandler, MaxCharsIndicator]
+}) => [InputValue, ChangeEventHandler, MaxCharsIndicator, IsDirty]
 
 export const useInputValue: UseInputValue = ({ value = "", onChange, maxChars }) => {
   const [inputValue, setValue] = useState(value)
+  const [isDirty, setIsDirty] = useState(false)
 
   const handleChange = useCallback(
     (e: ReactInputChangeEvent) => {
@@ -25,14 +27,17 @@ export const useInputValue: UseInputValue = ({ value = "", onChange, maxChars })
         return
       }
       setValue(newValue)
+      if (!isDirty) {
+        setIsDirty(true)
+      }
       if (onChange) {
         onChange(e)
       }
     },
-    [maxChars, onChange]
+    [isDirty, maxChars, onChange]
   )
 
   const maxCharsIndicator = maxChars ? `${inputValue.length}/${maxChars}` : ""
 
-  return [inputValue, handleChange, maxCharsIndicator]
+  return [inputValue, handleChange, maxCharsIndicator, isDirty]
 }


### PR DESCRIPTION
Inputs needs some flag to indicate if the value was ever changed, so the instant feedback fields (those that show validation status as you type, not onBlur) can be highlighted properly, not in empty state after render. I decided to place it into the hook, so we can be flexible and use other means of isDirty determination in the future (like the final-form provides its own isDirty flag).