### PR TITLE
Positive feedback priority feature added to input

### DIFF
--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -33,7 +33,7 @@ export interface ComponentProps {
   success?: boolean | string
   touched?: boolean
   isDirty?: boolean
-  instantFeedback?: boolean
+  instantFeedback?: "all" | "positiveFirst"
   className?: string
   fieldIndicator?: string | ReactNode
   metaShrinked?: boolean
@@ -48,6 +48,8 @@ Notable props:
 - `fieldMessage` - default message under the input field
 - `success` and `error` - status indicators, could be boolean or strings (in this case they render instead of `fieldMessage`)
 - `instantFeedback` - set this to true, if you want to provide validation status as user types, not onBlur/other.
+  With `all` updates validation status on any value change, with `positiveFirst` - only when string is successfully
+  validated (`success` prop), or user started to erase entered data and current string has errors according to `error` prop.
 - `isDirty` - boolean flag showing if something was ever entered into the input. Use together with instantFeedback.
 - `metaShrinked` - set this to true to not render any meta information and reserved space under the input field
 - `fieldIndicator` - additional information field, which could be used for displaying `maxChars` string or other meta info.

--- a/src/components/input/input.stories.tsx
+++ b/src/components/input/input.stories.tsx
@@ -78,15 +78,12 @@ inputStory.add(
 )
 
 inputStory.add(
-  "Input with instant feedback",
+  "Input with instant positive feedback",
   () => {
     const disabled = boolean("Disabled", false)
     const [isValid, setIsValid] = useState(false)
     const [validationMessage, setValidationMessage] = useState("")
-    const fieldMessage = text(
-      "Defailt field message",
-      "Pls fill this field for the sake of humanity"
-    )
+    const fieldMessage = text("Default field message", "Pls enter at least 5 characters")
     const charLimit = number("Max characters", 20)
 
     const onChange = useCallback(() => {
@@ -105,13 +102,13 @@ inputStory.add(
     const [touched, blurHandler] = useTouchedState({ onBlur })
 
     useEffect(() => {
-      if (!isValid && value.length > 0) {
+      if (!isValid && value.length >= 5) {
         setIsValid(true)
         setValidationMessage("Very green, much validated")
-      } else if (isValid && value.length === 0) {
+      } else if (isValid && value.length < 5) {
         setIsValid(false)
       }
-    }, [isValid, value.length, touched])
+    }, [isValid, value, touched])
 
     return (
       <Container>
@@ -126,7 +123,7 @@ inputStory.add(
           onChange={handleChange}
           success={isValid && validationMessage}
           error={!isValid}
-          instantFeedback
+          instantFeedback="positiveFirst"
           isDirty={isDirty}
         />
       </Container>

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, MutableRefObject, FocusEvent, ReactNode } from "react"
+import { usePreviousDistinct } from "react-use"
 import {
   StyledInput,
   StyledLabel,
@@ -12,6 +13,7 @@ import {
   FieldInfo,
   LabelRow,
 } from "./styled"
+import { InstantFeedback } from "./types"
 import { useFocusedState } from "./use-focused-state"
 
 export interface InputProps {
@@ -33,7 +35,7 @@ export interface ComponentProps {
   success?: boolean | string
   touched?: boolean
   isDirty?: boolean
-  instantFeedback?: boolean
+  instantFeedback?: InstantFeedback
   className?: string
   fieldIndicator?: string | ReactNode
   metaShrinked?: boolean
@@ -60,11 +62,22 @@ export const TextInput = ({
   placeholder = "",
   label,
   isDirty,
+  value,
   ...props
 }: TextInputProps) => {
   const [focused, handleFocus, handleBlur] = useFocusedState({ onBlur, onFocus })
 
-  const metaDisplayed = touched || (instantFeedback && isDirty)
+  const prevValue = usePreviousDistinct(value)
+
+  const metaDisplayed =
+    touched ||
+    (instantFeedback === "all" && isDirty) ||
+    (instantFeedback === "positiveFirst" && isDirty && success) ||
+    (instantFeedback === "positiveFirst" &&
+      isDirty &&
+      error &&
+      prevValue &&
+      value.length < prevValue.length) // if user starts to erase entered data, we provide negative feedback
   const isSuccess = metaDisplayed && success
   const isError = metaDisplayed && error
   const errorMessage = isError && error !== true && error
@@ -91,6 +104,7 @@ export const TextInput = ({
             iconLeft={iconLeft}
             iconRight={iconRight}
             type="text"
+            value={value}
           />
           {iconRight && <IconContainer disabled={disabled}>{iconRight}</IconContainer>}
           {metaDisplayed && error && (

--- a/src/components/input/types.ts
+++ b/src/components/input/types.ts
@@ -3,3 +3,5 @@ export type ReactInputChangeEvent = import("react").ChangeEvent<HTMLInputElement
 
 export type FocusEventHandler = (e: ReactFocusEvent) => void
 export type ChangeEventHandler = (e: ReactInputChangeEvent) => void
+
+export type InstantFeedback = "all" | "positiveFirst"


### PR DESCRIPTION
`instantFeedback` prop changed, now it's a string optional value. "positiveFirst"  doesn't scare the user with validation error if he just started to enter some data.  "all" left as it was before.