### PR TITLE
Added ability to skip auto-resets of table internal state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "0.7.5",
+  "version": "0.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16086,9 +16086,9 @@
       }
     },
     "react-table": {
-      "version": "7.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.0.0-rc.9.tgz",
-      "integrity": "sha512-KBu3jnnthpEPkNQZA/GTcNyfLqOAyF/Wkd2CA7CCxYWflNAM7i/cUj+IuNcSgJ/w+yIdnn/aAwsKwphlQ4RPhA=="
+      "version": "7.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.0.0-rc.15.tgz",
+      "integrity": "sha512-ofMOlgrioHhhvHjvjsQkxvfQzU98cqwy6BjPGNwhLN1vhgXeWi0mUGreaCPvRenEbTiXsQbMl4k3Xmx3Mut8Rw=="
     },
     "react-test-render": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "polished": "^3.4.1",
     "ramda": "^0.26.1",
     "react-portal": "^4.2.0",
-    "react-table": "^7.0.0-rc.9",
+    "react-table": "^7.0.0-rc.15",
     "react-use": "^12.7.1"
   },
   "peerDependencies": {

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -1,8 +1,8 @@
 ## Table component
 
-The implementation based on top of `react-table` lib and pretty generic at moment.
+The implementation based on `react-table` lib and pretty generic at moment.
 
-**CAUTION:** in future this component will most likely will be refactored
+**CAUTION:** in future this component will most likely be refactored
 
 ### Props:
 
@@ -12,13 +12,17 @@ interface TableProps<T, RT = any> {
   columns: RT
   data: T[]
   sortedBy?: string[]
+  autoResetSelectedRows?: boolean
+  autoResetSortBy?: boolean
 }
 ```
 
 - `selectedItemClb` - selected item callback. This one used for calling something whenever any row in table is selected
-- `coulmns` - This is where all the layout happens. As example user table `columns` provided below. As basis `react-table` **columns** used here.
-- `data` - collection of table rows as js objects. Each first level key of object should reference to `accessor` fild described in colums.
-- `sortedBy` - describs which colums could provide sorting API. Values should be referenced to `coulumnss` `accessor`
+- `columns` - This is where all the layout happens. As example user table `columns` provided below. As basis `react-table` **columns** used here.
+- `data` - collection of table rows as js objects. Each first level key of object should reference to `accessor` fild described in columns.
+- `sortedBy` - describes which columns could provide sorting API. Values should be referenced to `columns` `accessor`
+- `autoResetSelectedRows`, `autoResetSortBy` - `true` by default, pass `false` if the selection
+  and sorting order of rows need to be persisted through the re-renders when `data` prop changes.
 
 This is setup of first **column** with the selection checkbox
 

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { storiesOf } from "@storybook/react"
 import styled from "styled-components"
 import { Table } from "./table"
@@ -16,33 +16,69 @@ const subData = {
 }
 const sidebarStory = storiesOf("COMPONENTS|Controls/Table", module)
 
+const initialState = [
+  {
+    user: { photo: "https://i.pravatar.cc/30", name: "Fry", mail: "noway@noway.com" },
+    dots: "123",
+  },
+  {
+    user: { photo: "https://i.pravatar.cc/31", name: "Amy", mail: "amy@vong.com" },
+    dots: "123",
+  },
+  {
+    user: {
+      photo: "https://i.pravatar.cc/32",
+      name: "dr. Zoidberg",
+      mail: "drZ@planetmail.com",
+    },
+    dots: "123",
+  },
+]
+
 sidebarStory.add(
-  "Users table",
-  () => (
-    <Table
-      sortedBy={["user"]}
-      columns={UserTableSchema}
-      data={[
-        {
-          user: { photo: "https://i.pravatar.cc/30", name: "Fry", mail: "noway@noway.com" },
-          dots: "123",
-        },
-        {
-          user: { photo: "https://i.pravatar.cc/31", name: "Amy", mail: "amy@vong.com" },
-          dots: "123",
-        },
-        {
-          user: {
-            photo: "https://i.pravatar.cc/32",
-            name: "dr. Zoidberg",
-            mail: "drZ@planetmail.com",
-          },
-          dots: "123",
-        },
-      ]}
-      selectedItemsClb={items => console.log(items)}
-    />
-  ),
+  "Users table with selection persist",
+  () => {
+    const [state, setState] = useState(initialState)
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => {
+            const changedName = Math.random()
+              .toString()
+              .slice(0, 4)
+            setState([
+              {
+                user: { photo: "https://i.pravatar.cc/30", name: "Fry", mail: "noway@noway.com" },
+                dots: "123",
+              },
+              {
+                user: { photo: "https://i.pravatar.cc/31", name: "Amy", mail: "amy@vong.com" },
+                dots: "123",
+              },
+              {
+                user: {
+                  photo: "https://i.pravatar.cc/32",
+                  name: `Zoidberg #${changedName}`,
+                  mail: "drZ@planetmail.com",
+                },
+                dots: "123",
+              },
+            ])
+          }}
+        >
+          Reload Data
+        </button>
+        <Table
+          sortedBy={["user"]}
+          columns={UserTableSchema}
+          data={state}
+          selectedItemsClb={items => console.log(items)}
+          autoResetSelectedRows={false}
+        />
+      </div>
+    )
+  },
   subData
 )
 
@@ -57,24 +93,7 @@ sidebarStory.add(
     <StyledTable
       sortedBy={["user"]}
       columns={UserTableSchema}
-      data={[
-        {
-          user: { photo: "https://i.pravatar.cc/30", name: "Fry", mail: "noway@noway.com" },
-          dots: "123",
-        },
-        {
-          user: { photo: "https://i.pravatar.cc/31", name: "Amy", mail: "amy@vong.com" },
-          dots: "123",
-        },
-        {
-          user: {
-            photo: "https://i.pravatar.cc/32",
-            name: "dr. Zoidberg",
-            mail: "drZ@planetmail.com",
-          },
-          dots: "123",
-        },
-      ]}
+      data={initialState}
       selectedItemsClb={items => console.log(items)}
     />
   ),

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -8,6 +8,8 @@ interface TableProps<T, RT = any> {
   data: T[]
   sortedBy?: string[]
   className?: string
+  autoResetSelectedRows?: boolean
+  autoResetSortBy?: boolean
 }
 
 function ReactTable<T extends object>({
@@ -15,11 +17,22 @@ function ReactTable<T extends object>({
   data,
   sortedBy = [],
   selectedItemsClb,
+  autoResetSelectedRows = true,
+  autoResetSortBy = true,
   ...props
 }: TableProps<T>) {
   // @ts-ignore
-  const { getTableBodyProps, headerGroups, rows, prepareRow, selectedFlatRows, ...rest } = useTable(
-    { columns, data },
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+    selectedFlatRows,
+    ...rest
+  } = useTable(
+    // @ts-ignore
+    { columns, data, autoResetSelectedRows, autoResetSortBy },
     useSortBy,
     useRowSelect
   )
@@ -27,10 +40,10 @@ function ReactTable<T extends object>({
     if (selectedItemsClb) {
       selectedItemsClb(selectedFlatRows.map((r: Row<T>) => r.original))
     }
-  }, [selectedFlatRows])
+  }, [selectedFlatRows, selectedItemsClb])
 
   return (
-    <StyledTable {...props}>
+    <StyledTable {...props} {...getTableProps()}>
       <StyledThead>
         {headerGroups.map((headerGroup, i) => (
           <tr key={i}>
@@ -70,12 +83,12 @@ export function Table<T extends object>({
   columns,
   ...props
 }: TableProps<T>) {
-  const cahedColumns = React.useMemo<typeof columns>(() => columns, [])
+  const cachedColumns = React.useMemo<typeof columns>(() => columns, [columns])
 
   return (
     <ReactTable<T>
       selectedItemsClb={selectedItemsClb}
-      columns={cahedColumns}
+      columns={cachedColumns}
       sortedBy={sortedBy}
       data={data}
       {...props}


### PR DESCRIPTION
We need to persist some parts of table internal state between re-renders, as the table data derived from selector can change frequently (we can poll for it, for example).
Details:

https://github.com/tannerlinsley/react-table/issues/1729#issuecomment-562783308