### PR TITLE
Groups custom ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -14,6 +14,11 @@ from flattened array, or to render groups some other way.
 
 ```typescript
 interface TableProps<T, RT = any> {
+  groupsOrderValues?: {
+    [groupID: string]: {
+      [groupValue: string]: number
+    }
+  }
   selectedItemsClb?: (items: T[]) => T[] | void
   columns: RT
   data: T[]
@@ -55,6 +60,8 @@ interface TableProps<T, RT = any> {
 - `renderGroupHead` - custom rendering for row indicating a header group, defaults to empty row with group name
 - `callbackRef` - callback function should be passed to establish ref to the Table when it's will be rendered
 - `groupByFn` - function used to group rows, defaults to one `react-table` is using
+- `groupsOrderValues` - config object to define order of groups by grouping id (refers to column id/accessor),
+  default sort order used if the prop not provided
 
 This is setup of first **column** with the selection checkbox
 

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -157,6 +157,15 @@ const nodesData = [
   },
 ]
 
+const groupsOrderValues = {
+  status: {
+    critical: 0,
+    warning: 1,
+    unreachable: 2,
+    okay: 3,
+  },
+}
+
 const prepareData = (arr: any) =>
   arr.reduce((a, c) => {
     const {
@@ -266,6 +275,7 @@ tableStory.add(
                 setTableRef({ current: node })
               }
             }}
+            groupsOrderValues={groupsOrderValues}
             layoutType="block"
             controlledState={controlledState}
             initialState={blockTableInitialState}

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -1,8 +1,8 @@
-import { RowInstance } from "react-table"
+import { pipe, sortBy, prop, map, path } from "ramda"
 // default  grouping function from the react-table utils
 
 type DefaultGroupByFn = (rows: any[], columnId: string) => { [groupName: string]: any[] }
-export function defaultGroupByFn(rows, columnId) {
+export const defaultGroupByFn: DefaultGroupByFn = (rows, columnId) => {
   const result = rows.reduce((prev, row) => {
     const resKey = `${row.values[columnId]}`
     prev[resKey] = Array.isArray(prev[resKey]) ? prev[resKey] : []
@@ -11,3 +11,18 @@ export function defaultGroupByFn(rows, columnId) {
   }, {})
   return result
 }
+
+export type GroupsOrderValues = {
+  [groupID: string]: {
+    [groupValue: string]: number
+  }
+}
+
+export const sortGroupsByPriority = (groups: any[], groupOrderValues: GroupsOrderValues) =>
+  pipe(
+    map((group: any) => ({
+      ...group,
+      priority: path([group.groupByID, group.groupByVal], groupOrderValues),
+    })),
+    sortBy(prop("priority"))
+  )(groups)


### PR DESCRIPTION
Support for config object, used to define order for groups - like, if we group by alarm status, it goes
critical > warning > ok, not in alphabetic order by group name (default).