### PR TITLE
Virtualized keys / renderer fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "0.7.30",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -141,6 +141,11 @@ Exclusions:
   Also, `verticalGutter` value should be added to each item calculated height, to maintain
   sizes accurate.
 
+- `itemKey` - works the same way as default `react-window` lists prop with same name, but
+  our wrapper always puts `{orderedRows}` inside `data` argument object, which contains
+  flattened and ordered array of all rows (including group headers), which could be used
+  for generating keys.
+
 **Note on tradeoffs and usage**
 
 1. Requires numeric width and height of the container. `useMeasure` from `react-use` handles

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -122,6 +122,7 @@ interface VTableProps<T, RT = any> extends TableProps<T, RT> {
     overscanCount?: number
     verticalGutter?: number
     itemKey?: (index: number, data: any) => string
+    rendererHash?: string
   }
 }
 ```
@@ -145,6 +146,10 @@ Exclusions:
   our wrapper always puts `{orderedRows}` inside `data` argument object, which contains
   flattened and ordered array of all rows (including group headers), which could be used
   for generating keys.
+
+- `rendererHash` - hash used as dependency for memoizing virtualized row renderer callback function.
+  Could be used to determine, if the function should be re-created to render a changed data, but without
+  direct connection to the data object on instance level
 
 **Note on tradeoffs and usage**
 

--- a/src/components/table/components/sticky-virtual-list/sticky-virtual-list.tsx
+++ b/src/components/table/components/sticky-virtual-list/sticky-virtual-list.tsx
@@ -61,6 +61,7 @@ interface Props {
   customProps: unknown
   callbackRef: any
   itemKey?: (index: number, data: any) => string
+  orderedRows: []
 }
 
 export const StickyVirtualList = ({
@@ -74,6 +75,8 @@ export const StickyVirtualList = ({
   layoutType,
   variableSize,
   callbackRef,
+  itemKey,
+  orderedRows,
   ...rest
 }: Props) => (
   <StickyListContextProvider
@@ -89,11 +92,21 @@ export const StickyVirtualList = ({
     }}
   >
     {variableSize ? (
-      <StyledVariableList itemData={{ ItemRenderer: children }} ref={callbackRef} {...rest}>
+      <StyledVariableList
+        itemData={{ ItemRenderer: children, orderedRows }}
+        ref={callbackRef}
+        itemKey={itemKey}
+        {...rest}
+      >
         {ItemWrapper}
       </StyledVariableList>
     ) : (
-      <StyledFixedList itemData={{ ItemRenderer: children }} ref={callbackRef} {...rest}>
+      <StyledFixedList
+        itemData={{ ItemRenderer: children, orderedRows }}
+        ref={callbackRef}
+        itemKey={itemKey}
+        {...rest}
+      >
         {ItemWrapper}
       </StyledFixedList>
     )}

--- a/src/components/table/virtualized-table.stories.tsx
+++ b/src/components/table/virtualized-table.stories.tsx
@@ -7,7 +7,6 @@ import { NodesTableSchema } from "./mocks/nodes-table-schema"
 import { readmeCleanup } from "../../../utils/readme"
 // @ts-ignore
 import readme from "./README.md"
-import { webkitVisibleScrollbar } from "../../mixins"
 import { customGroupBy } from "./mocks/utils"
 
 const subData = {
@@ -78,6 +77,11 @@ const nodesData = [
 
 const virtualNodesData = [...nodesData, ...sampleNodes]
 
+const getItemKey = (index, data) => {
+  const row = data.orderedRows[index]
+  return `${(row.original && row.original.node.name) || row.id} ${index}`
+}
+
 const nodeHeights = virtualNodesData.map(() => 25 + Math.round(Math.random() * 50))
 const getItemHeight = (index: number) => nodeHeights[index] + 8
 
@@ -113,8 +117,6 @@ const prepareData = (arr: any) =>
     }
     return [...a, { ...c, status }]
   }, [])
-
-const virtualizedData = prepareData(virtualNodesData)
 
 const NoScrollContainer = styled.div`
   position: relative;
@@ -176,6 +178,10 @@ virtualizedTableStory.add(
   () => {
     const [groupBy, setGroupBy] = useState([] as string[])
     const [tableRef, setTableRef] = useState({ current: null }) as any
+    const [nodes, setNodes] = useState(virtualNodesData)
+    console.info(nodes)
+
+    const virtualizedData = useMemo(() => prepareData(nodes), [nodes])
 
     const controlledState = useMemo(
       () => ({
@@ -193,6 +199,7 @@ virtualizedTableStory.add(
         itemSize: getItemHeight,
         variableSize: true,
         verticalGutter: 8,
+        itemKey: getItemKey,
       }),
       [width, height]
     )
@@ -215,11 +222,21 @@ virtualizedTableStory.add(
               <option value="services"> Services </option>
             </select>
           </label>
+          <button
+            type="button"
+            onClick={() => {
+              const [first, ...rest] = nodes
+              setNodes(rest)
+            }}
+          >
+            delete first
+          </button>
         </div>
         <NoScrollContainer ref={ref}>
           {width > 0 && height > 0 && (
             <MemoizedVirtualTable<Node>
               callbackRef={node => {
+                console.log("rerender")
                 if (tableRef.current === null && node !== null) {
                   setTableRef({ current: node })
                 }

--- a/src/components/table/virtualized-table.stories.tsx
+++ b/src/components/table/virtualized-table.stories.tsx
@@ -179,7 +179,6 @@ virtualizedTableStory.add(
     const [groupBy, setGroupBy] = useState([] as string[])
     const [tableRef, setTableRef] = useState({ current: null }) as any
     const [nodes, setNodes] = useState(virtualNodesData)
-    console.info(nodes)
 
     const virtualizedData = useMemo(() => prepareData(nodes), [nodes])
 
@@ -200,8 +199,11 @@ virtualizedTableStory.add(
         variableSize: true,
         verticalGutter: 8,
         itemKey: getItemKey,
+        rendererHash: nodes.reduce((acc, current) => {
+          return `${acc}${current.node.name}`
+        }, ""),
       }),
-      [width, height]
+      [width, height, nodes]
     )
 
     return (
@@ -236,7 +238,6 @@ virtualizedTableStory.add(
           {width > 0 && height > 0 && (
             <MemoizedVirtualTable<Node>
               callbackRef={node => {
-                console.log("rerender")
                 if (tableRef.current === null && node !== null) {
                   setTableRef({ current: node })
                 }

--- a/src/components/table/virtualized-table.tsx
+++ b/src/components/table/virtualized-table.tsx
@@ -52,7 +52,7 @@ export function VirtualizedTable<T extends object>({
     overscanCount,
     itemSize,
     verticalGutter = 0,
-    itemKey,
+    itemKey = (index: number) => String(index),
   },
   callbackRef,
   ...customProps
@@ -171,6 +171,7 @@ export function VirtualizedTable<T extends object>({
         overscanCount={overscanCount}
         callbackRef={callbackRef}
         itemKey={itemKey}
+        orderedRows={orderedRows}
       >
         {renderVirtualizedRow}
       </StickyVirtualList>

--- a/src/components/table/virtualized-table.tsx
+++ b/src/components/table/virtualized-table.tsx
@@ -14,6 +14,8 @@ import { tableHooks, blockTableHooks } from "./table-hooks"
 
 type GetItemSize = (index: number, orderedRows: any) => number
 
+const itemKeyFallback = (index: number) => String(index)
+
 interface VTableProps<T, RT = any> extends TableProps<T, RT> {
   virtualizedSettings: {
     width: number
@@ -53,7 +55,7 @@ export function VirtualizedTable<T extends object>({
     overscanCount,
     itemSize,
     verticalGutter = 0,
-    itemKey = (index: number) => String(index),
+    itemKey = itemKeyFallback,
     rendererHash,
   },
   callbackRef,

--- a/src/components/table/virtualized-table.tsx
+++ b/src/components/table/virtualized-table.tsx
@@ -23,6 +23,7 @@ interface VTableProps<T, RT = any> extends TableProps<T, RT> {
     overscanCount?: number
     verticalGutter?: number
     itemKey?: (index: number, data: any) => string
+    rendererHash?: string
   }
 }
 
@@ -53,6 +54,7 @@ export function VirtualizedTable<T extends object>({
     itemSize,
     verticalGutter = 0,
     itemKey = (index: number) => String(index),
+    rendererHash,
   },
   callbackRef,
   ...customProps
@@ -62,6 +64,8 @@ export function VirtualizedTable<T extends object>({
     columns,
     controlledState.columnOrder,
   ])
+
+  const protectedRendererHash = useMemo(() => rendererHash || "stableFallback", [rendererHash])
 
   const reactTableHooks = layoutType === "block" ? blockTableHooks : tableHooks
 
@@ -126,13 +130,8 @@ export function VirtualizedTable<T extends object>({
   )
 
   // TODO
-  // We can come up with declarative API for that, but now the solution is
-  // to depend on anything that can change order of items (grouping, filtering),
-  // so the indexes won't represent same items.
-
-  // This overall introduces some implicit details of how list rendering works,
-  // but its unclear what is the desired abstraction.
-  // Better tradeoff TBD.
+  // find out what place selectedRowsIds have there
+  // and if rendererHash is the better tradeoff
 
   const renderVirtualizedRow = useCallback(
     ({ index, style }) => {
@@ -151,7 +150,7 @@ export function VirtualizedTable<T extends object>({
       )
     },
     // eslint-disable-next-line
-    [controlledState, selectedRowIds, renderGroupHead, verticalGutter]
+    [controlledState, selectedRowIds, renderGroupHead, verticalGutter, protectedRendererHash]
   )
   return (
     <LayoutContextProvider value={layoutType}>


### PR DESCRIPTION
Contains solutions for 2 problems:

1) Consistent generation of `key` for virtualized item wrappers for dynamic data, based on `react-window` `itemKey` prop
2) Introduced hash as dependency for re-creating virtualized row renderer callback function, to support dynamic changes and not remount the rows too frequently