### PR TITLE
Toggle component

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "printWidth": 100,
   "useTabs": false,
-  "singleQuote": false
+  "singleQuote": false,
+  "arrowParens": "avoid",
 }

--- a/src/components/toggle/README.md
+++ b/src/components/toggle/README.md
@@ -1,0 +1,32 @@
+## Toggle component
+
+The implementation requires controlled behaviour, so the component has to be provided with state and handler.
+
+### Props:
+
+```typescript
+interface ToggleProps {
+  checked: boolean
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  id?: string
+  labelLeft?: string
+  labelRight?: string
+  Label?: React.ComponentType<any>
+  colored?: boolean
+  ref?: React.MutableRefObject<HTMLInputElement>
+  className?: string
+  disabled?: boolean
+}
+```
+
+### Typical usage:
+
+```JSX
+export const ContolledToggle = () => {
+  const [checked, setChecked] = useState(false)
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.currentTarget.checked)
+  }
+  return <Toggle onChange={handleChange} checked={checked} />
+}
+```

--- a/src/components/toggle/__snapshots__/toggle.test.tsx.snap
+++ b/src/components/toggle/__snapshots__/toggle.test.tsx.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Toggle test  * should render with labels 1`] = `
+.c1 {
+  font-family: "IBM Plex Sans",sans-serif;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 14px;
+  line-height: 18px;
+}
+
+.c3 {
+  display: block;
+  box-sizing: border-box;
+  width: 40px;
+  height: 20px;
+}
+
+.c5 {
+  display: none;
+}
+
+.c6 {
+  box-sizing: border-box;
+  width: 40px;
+  height: 20px;
+  background: #FFF;
+  border: 1px solid #AEB3B7;
+  border-radius: 100px;
+  -webkit-transition: all 150ms;
+  transition: all 150ms;
+  display: block;
+  position: relative;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  cursor: pointer;
+}
+
+.c6:after {
+  display: block;
+  position: absolute;
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  left: 5%;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: left 0.2s ease;
+  transition: left 0.2s ease;
+  background-color: #35414A;
+}
+
+.c4:focus + .c6 {
+  border-color: #35414A;
+  box-shadow: 0 0 0 1px #35414A;
+}
+
+.c0 {
+  position: relative;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  margin-right: 8px;
+}
+
+.c7 {
+  margin-left: 8px;
+}
+
+<div>
+  <label
+    class="c0"
+  >
+    <span
+      class="c1 c2"
+    >
+      Dark theme
+    </span>
+    <div
+      class="c3"
+    >
+      <input
+        class="c4 c5"
+        type="checkbox"
+      />
+      <div
+        class="c6"
+        role="switch"
+      />
+    </div>
+    <span
+      class="c1 c7"
+    >
+      Light theme
+    </span>
+  </label>
+</div>
+`;
+
+exports[`Toggle test  * should render with required props 1`] = `
+.c1 {
+  display: block;
+  box-sizing: border-box;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 {
+  display: none;
+}
+
+.c4 {
+  box-sizing: border-box;
+  width: 40px;
+  height: 20px;
+  background: #FFF;
+  border: 1px solid #AEB3B7;
+  border-radius: 100px;
+  -webkit-transition: all 150ms;
+  transition: all 150ms;
+  display: block;
+  position: relative;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  cursor: pointer;
+}
+
+.c4:after {
+  display: block;
+  position: absolute;
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  left: 5%;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: left 0.2s ease;
+  transition: left 0.2s ease;
+  background-color: #35414A;
+}
+
+.c2:focus + .c4 {
+  border-color: #35414A;
+  box-shadow: 0 0 0 1px #35414A;
+}
+
+.c0 {
+  position: relative;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+<div>
+  <label
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <input
+        class="c2 c3"
+        type="checkbox"
+      />
+      <div
+        class="c4"
+        role="switch"
+      />
+    </div>
+  </label>
+</div>
+`;

--- a/src/components/toggle/index.ts
+++ b/src/components/toggle/index.ts
@@ -1,0 +1,1 @@
+export { Toggle, ToggleProps } from "./toggle"

--- a/src/components/toggle/styled.tsx
+++ b/src/components/toggle/styled.tsx
@@ -1,0 +1,86 @@
+import React from "react"
+import styled from "styled-components"
+import { getColor, getSizeUnit } from "../../theme/utils"
+import { controlFocused } from "../../mixins"
+
+export const ToggleContainer = styled.div`
+  display: block;
+  box-sizing: border-box;
+  width: 40px;
+  height: 20px;
+`
+
+export const HiddenToggleInput = styled.input.attrs({
+  type: "checkbox",
+})`
+  display: none;
+`
+
+export const StyledToggle = styled.div<{
+  checked: boolean
+  disabled?: boolean
+  colored?: boolean
+}>`
+  box-sizing: border-box;
+  width: 40px;
+  height: 20px;
+  background: ${getColor(["white", "pure"])};
+  border: 1px solid ${getColor(["gray", "bombay"])};
+  border-radius: 100px;
+  transition: all 150ms;
+
+  display: block;
+  position: relative;
+
+  -webkit-tap-highlight-color: transparent;
+  flex-shrink: 0;
+  align-self: flex-start;
+  cursor: pointer;
+
+  &:after {
+    display: block;
+    position: absolute;
+    content: "";
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    left: 5%;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: left 0.2s ease;
+    background-color: ${({ disabled, colored, checked }) => {
+      if (disabled) return getColor(["gray", "gainsboro"])
+      if (!colored) return getColor(["gray", "limedSpruce"])
+      return checked ? getColor(["green", "greenHaze"]) : getColor(["red", "redOrange"])
+    }};
+  }
+
+  ${({ checked }) =>
+    checked &&
+    `
+    &:after {
+      left: 55%;
+    }
+  `}
+
+  ${HiddenToggleInput}:focus + & {
+    ${controlFocused}
+  }
+`
+
+export const StyledLabel = styled.label`
+  position: relative;
+  cursor: pointer;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+`
+
+export const LabelText = styled.span<{
+  left?: boolean
+  right?: boolean
+  as?: React.ComponentType<any>
+}>`
+  ${({ right, ...props }) =>
+    right ? `margin-left: ${getSizeUnit(props)}px;` : `margin-right: ${getSizeUnit(props)}px;`}
+`

--- a/src/components/toggle/toggle.stories.tsx
+++ b/src/components/toggle/toggle.stories.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react"
+import { storiesOf } from "@storybook/react"
+import { text, boolean } from "@storybook/addon-knobs"
+import { Toggle } from "."
+import { readmeCleanup } from "../../../utils/readme"
+// @ts-ignore
+import readme from "./README.md"
+
+const toggleStory = storiesOf("COMPONENTS|Controls/Toggle", module)
+type LeftOrRight = "left" | "right"
+
+const subData = {
+  readme: {
+    sidebar: readmeCleanup(readme),
+  },
+  jest: ["toggle.test.tsx"],
+}
+
+toggleStory.add(
+  "Toggle",
+  () => {
+    const [checked, setChecked] = useState(false)
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setChecked(e.currentTarget.checked)
+    }
+    return (
+      <Toggle
+        labelRight={text("Label right", "Do you like greek salad?")}
+        disabled={boolean("Disabled", false)}
+        onChange={handleChange}
+        checked={checked}
+        colored={boolean("Colored", true)}
+      />
+    )
+  },
+  subData
+)
+
+toggleStory.add(
+  "Two options Toggle",
+  () => {
+    const [checked, setChecked] = useState(false)
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setChecked(e.currentTarget.checked)
+    }
+    return (
+      <Toggle
+        labelRight={text("Label right", "Light theme")}
+        labelLeft={text("Label left", "Dark theme")}
+        onChange={handleChange}
+        checked={checked}
+        disabled={boolean("Disabled", false)}
+        colored={boolean("Colored", false)}
+      />
+    )
+  },
+  subData
+)

--- a/src/components/toggle/toggle.test.tsx
+++ b/src/components/toggle/toggle.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React, { useState } from "react"
+import { fireEvent } from "@testing-library/react"
+import { DefaultTheme } from "../../theme/default"
+import { testWrapper } from "../../../test-utils"
+import "@testing-library/jest-dom/extend-expect"
+import "jest-styled-components"
+import { Toggle } from "."
+
+const MockedToggle = props => {
+  const [checked, setChecked] = useState(false)
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.currentTarget.checked)
+  }
+  return <Toggle onChange={handleChange} checked={checked} {...props} />
+}
+
+describe("Toggle test", () => {
+  it(" * should render with required props", () => {
+    const { container, getByRole } = testWrapper<object>(MockedToggle, {}, DefaultTheme, null)
+    const checkbox = container.querySelectorAll("input")[0]
+    expect(checkbox).toBeInTheDocument()
+
+    const toggle = getByRole("switch")
+    expect(toggle).toHaveStyleRule("background", "#FFF")
+    expect(toggle).toHaveStyleRule("background-color", "#35414A", { modifier: ":after" })
+    expect(container).toMatchSnapshot()
+  })
+
+  it(" * should render with labels", () => {
+    const { container, getByText } = testWrapper<object>(
+      MockedToggle,
+      { labelRight: "Light theme", labelLeft: "Dark theme" },
+      DefaultTheme,
+      null
+    )
+    expect(getByText(/Light theme/)).toBeInTheDocument()
+    expect(getByText(/Dark theme/)).toBeInTheDocument()
+    expect(container).toMatchSnapshot()
+  })
+
+  it(" * should be disabled", () => {
+    const { container, getByRole } = testWrapper<object>(
+      MockedToggle,
+      { disabled: true },
+      DefaultTheme,
+      null
+    )
+    const checkbox = container.querySelectorAll("input")[0]
+    expect(checkbox).toBeDisabled()
+
+    const toggle = getByRole("switch")
+    expect(toggle).toHaveStyleRule("background-color", "#D8D8D8", { modifier: ":after" })
+  })
+
+  it(" * should be colored", () => {
+    const { container, getByRole } = testWrapper<object>(
+      MockedToggle,
+      { colored: true },
+      DefaultTheme,
+      null
+    )
+    const toggle = getByRole("switch")
+    expect(toggle).toHaveStyleRule("background-color", "#FF4136", { modifier: ":after" })
+
+    const checkbox = container.querySelectorAll("input")[0]
+    fireEvent.click(checkbox)
+    expect(toggle).toHaveStyleRule("background-color", "#00AB44", { modifier: ":after" })
+  })
+
+  it(" * should check the checkbox on interaction", () => {
+    const { container } = testWrapper<object>(MockedToggle, {}, DefaultTheme, null)
+    const checkbox = container.querySelectorAll("input")[0]
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(true)
+
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(false)
+  })
+})

--- a/src/components/toggle/toggle.tsx
+++ b/src/components/toggle/toggle.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from "react"
+import { Text } from "../typography"
+import { ToggleContainer, HiddenToggleInput, StyledToggle, StyledLabel, LabelText } from "./styled"
+
+export interface ToggleProps {
+  checked: boolean
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  id?: string
+  labelLeft?: string
+  labelRight?: string
+  Label?: React.ComponentType<any>
+  colored?: boolean
+  ref?: React.MutableRefObject<HTMLInputElement>
+  className?: string
+  disabled?: boolean
+}
+
+export const Toggle: FC<ToggleProps> = ({
+  checked,
+  disabled,
+  className,
+  labelLeft,
+  labelRight,
+  Label,
+  colored,
+  ...props
+}: ToggleProps) => (
+  <StyledLabel className={className}>
+    {labelLeft && (
+      <LabelText as={Label} left>
+        {labelLeft}
+      </LabelText>
+    )}
+    <ToggleContainer>
+      <HiddenToggleInput disabled={disabled} checked={checked} {...props} />
+      <StyledToggle checked={checked} disabled={disabled} colored={colored} role="switch" />
+    </ToggleContainer>
+    {labelRight && (
+      <LabelText as={Label} right>
+        {labelRight}
+      </LabelText>
+    )}
+  </StyledLabel>
+)
+
+Toggle.defaultProps = {
+  colored: false,
+  Label: Text,
+}

--- a/src/theme/declarations.ts
+++ b/src/theme/declarations.ts
@@ -12,6 +12,7 @@ export type RawColorsT = {
     silverSand: string
     gallery: string
     guyabano: string
+    gainsboro: string
   }
   green: {
     malachite: string

--- a/src/theme/default/colors.ts
+++ b/src/theme/default/colors.ts
@@ -14,6 +14,7 @@ const rawColors: RawColorsT = {
     silverSand: "#B5B9BC",
     gallery: "#EFEFEF",
     guyabano: "#F7F8F8",
+    gainsboro: "#D8D8D8",
   },
   green: {
     malachite: "#00CB51",


### PR DESCRIPTION
Introduced a new toggle component according to  https://www.figma.com/file/f7kwppd2Wt8xYi6FSOR2XK/%F0%9F%93%A6Netdata-Design-Elements

I did a custom/simple implementation without any UI framework, since toggle is just a fancy checkbox.

I added an extra prop for the Label component, in case we want to change the label according to the typography components (by default it's the normal 14px Text). If you feel in won't be used I can remove it before merge, or if it's going to be used, I can make the same change for checkboxes as well.

As a final note, do we care about uncontrolled toggles?