### PR TITLE
Allow button to work with other tags.

### DIFF
--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Borderless Button  * should render 1`] = `
-.c0 {
+.c0.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -35,29 +35,33 @@ exports[`Borderless Button  * should render 1`] = `
   border-color: rgba(255,255,255,0.0);
   border-radius: 2px;
   box-sizing: border-box;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover {
+.c0.c0:hover {
   border-color: rgba(255,255,255,0.0);
   background-color: rgba(255,255,255,0.0);
   color: #00CB51;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover .button-icon {
+.c0.c0:hover .button-icon {
   fill: #00CB51;
 }
 
-.c0:active {
+.c0.c0:active {
   border-color: rgba(255,255,255,0.0);
   background-color: rgba(255,255,255,0.0);
   color: #00AB44;
 }
 
-.c0:focus {
+.c0.c0:focus {
   outline: none;
 }
 
-.c0 .button-icon {
+.c0.c0 .button-icon {
   position: absolute;
   left: 4px;
   height: 16px;
@@ -65,7 +69,7 @@ exports[`Borderless Button  * should render 1`] = `
   fill: #FFF;
 }
 
-.c0 .ntd-spinner {
+.c0.c0 .ntd-spinner {
   fill: none;
   stroke-width: 17px;
   stroke-dasharray: 100;
@@ -76,7 +80,7 @@ exports[`Borderless Button  * should render 1`] = `
   width: 24px;
 }
 
-.c0 .path {
+.c0.c0 .path {
   stroke: #fff;
 }
 
@@ -90,7 +94,7 @@ exports[`Borderless Button  * should render 1`] = `
 `;
 
 exports[`Button states  * should render loading icon 1`] = `
-.c0 {
+.c0.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -124,29 +128,33 @@ exports[`Button states  * should render loading icon 1`] = `
   border-color: #00AB44;
   border-radius: 2px;
   box-sizing: border-box;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover {
+.c0.c0:hover {
   border-color: #00CB51;
   background-color: #00AB44;
   color: #FFF;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover .button-icon {
+.c0.c0:hover .button-icon {
   fill: #FFF;
 }
 
-.c0:active {
+.c0.c0:active {
   border-color: #00CB51;
   background-color: #00CB51;
   color: #FFF;
 }
 
-.c0:focus {
+.c0.c0:focus {
   outline: none;
 }
 
-.c0 .button-icon {
+.c0.c0 .button-icon {
   position: absolute;
   left: 4px;
   height: 16px;
@@ -154,7 +162,7 @@ exports[`Button states  * should render loading icon 1`] = `
   fill: #FFF;
 }
 
-.c0 .ntd-spinner {
+.c0.c0 .ntd-spinner {
   fill: none;
   stroke-width: 17px;
   stroke-dasharray: 100;
@@ -165,7 +173,7 @@ exports[`Button states  * should render loading icon 1`] = `
   width: 24px;
 }
 
-.c0 .path {
+.c0.c0 .path {
   stroke: #fff;
 }
 
@@ -214,7 +222,7 @@ exports[`Button states  * should render loading icon 1`] = `
 `;
 
 exports[`Button states  * should render only icon 1`] = `
-.c0 {
+.c0.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -248,29 +256,33 @@ exports[`Button states  * should render only icon 1`] = `
   border-color: #00AB44;
   border-radius: 2px;
   box-sizing: border-box;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover {
+.c0.c0:hover {
   border-color: #00CB51;
   background-color: rgba(255,255,255,0.0);
   color: #00CB51;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover .button-icon {
+.c0.c0:hover .button-icon {
   fill: #00CB51;
 }
 
-.c0:active {
+.c0.c0:active {
   border-color: #00CB51;
   background-color: rgba(255,255,255,0.0);
   color: #FFF;
 }
 
-.c0:focus {
+.c0.c0:focus {
   outline: none;
 }
 
-.c0 .button-icon {
+.c0.c0 .button-icon {
   position: absolute;
   left: auto;
   height: 16px;
@@ -278,7 +290,7 @@ exports[`Button states  * should render only icon 1`] = `
   fill: #00AB44;
 }
 
-.c0 .ntd-spinner {
+.c0.c0 .ntd-spinner {
   fill: none;
   stroke-width: 17px;
   stroke-dasharray: 100;
@@ -289,7 +301,7 @@ exports[`Button states  * should render only icon 1`] = `
   width: 24px;
 }
 
-.c0 .path {
+.c0.c0 .path {
   stroke: #fff;
 }
 
@@ -313,7 +325,7 @@ exports[`Button states  * should render only icon 1`] = `
 `;
 
 exports[`Button states  * should render smaller only icon 1`] = `
-.c0 {
+.c0.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -347,29 +359,33 @@ exports[`Button states  * should render smaller only icon 1`] = `
   border-color: #00AB44;
   border-radius: 2px;
   box-sizing: border-box;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover {
+.c0.c0:hover {
   border-color: #00CB51;
   background-color: rgba(255,255,255,0.0);
   color: #00CB51;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover .button-icon {
+.c0.c0:hover .button-icon {
   fill: #00CB51;
 }
 
-.c0:active {
+.c0.c0:active {
   border-color: #00CB51;
   background-color: rgba(255,255,255,0.0);
   color: #FFF;
 }
 
-.c0:focus {
+.c0.c0:focus {
   outline: none;
 }
 
-.c0 .button-icon {
+.c0.c0 .button-icon {
   position: absolute;
   left: auto;
   height: 16px;
@@ -377,7 +393,7 @@ exports[`Button states  * should render smaller only icon 1`] = `
   fill: #00AB44;
 }
 
-.c0 .ntd-spinner {
+.c0.c0 .ntd-spinner {
   fill: none;
   stroke-width: 17px;
   stroke-dasharray: 100;
@@ -388,7 +404,7 @@ exports[`Button states  * should render smaller only icon 1`] = `
   width: 24px;
 }
 
-.c0 .path {
+.c0.c0 .path {
   stroke: #fff;
 }
 
@@ -412,7 +428,7 @@ exports[`Button states  * should render smaller only icon 1`] = `
 `;
 
 exports[`Default Button  * should render 1`] = `
-.c0 {
+.c0.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -446,29 +462,33 @@ exports[`Default Button  * should render 1`] = `
   border-color: #00AB44;
   border-radius: 2px;
   box-sizing: border-box;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover {
+.c0.c0:hover {
   border-color: #00CB51;
   background-color: #00AB44;
   color: #FFF;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover .button-icon {
+.c0.c0:hover .button-icon {
   fill: #FFF;
 }
 
-.c0:active {
+.c0.c0:active {
   border-color: #00CB51;
   background-color: #00CB51;
   color: #FFF;
 }
 
-.c0:focus {
+.c0.c0:focus {
   outline: none;
 }
 
-.c0 .button-icon {
+.c0.c0 .button-icon {
   position: absolute;
   left: 4px;
   height: 16px;
@@ -476,7 +496,7 @@ exports[`Default Button  * should render 1`] = `
   fill: #FFF;
 }
 
-.c0 .ntd-spinner {
+.c0.c0 .ntd-spinner {
   fill: none;
   stroke-width: 17px;
   stroke-dasharray: 100;
@@ -487,7 +507,7 @@ exports[`Default Button  * should render 1`] = `
   width: 24px;
 }
 
-.c0 .path {
+.c0.c0 .path {
   stroke: #fff;
 }
 
@@ -501,7 +521,7 @@ exports[`Default Button  * should render 1`] = `
 `;
 
 exports[`Hollow Button  * should render 1`] = `
-.c0 {
+.c0.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -535,29 +555,33 @@ exports[`Hollow Button  * should render 1`] = `
   border-color: #00AB44;
   border-radius: 2px;
   box-sizing: border-box;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover {
+.c0.c0:hover {
   border-color: #00CB51;
   background-color: rgba(255,255,255,0.0);
   color: #00CB51;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c0:hover .button-icon {
+.c0.c0:hover .button-icon {
   fill: #00CB51;
 }
 
-.c0:active {
+.c0.c0:active {
   border-color: #00CB51;
   background-color: rgba(255,255,255,0.0);
   color: #FFF;
 }
 
-.c0:focus {
+.c0.c0:focus {
   outline: none;
 }
 
-.c0 .button-icon {
+.c0.c0 .button-icon {
   position: absolute;
   left: 4px;
   height: 16px;
@@ -565,7 +589,7 @@ exports[`Hollow Button  * should render 1`] = `
   fill: #00AB44;
 }
 
-.c0 .ntd-spinner {
+.c0.c0 .ntd-spinner {
   fill: none;
   stroke-width: 17px;
   stroke-dasharray: 100;
@@ -576,7 +600,7 @@ exports[`Hollow Button  * should render 1`] = `
   width: 24px;
 }
 
-.c0 .path {
+.c0.c0 .path {
   stroke: #fff;
 }
 

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -18,8 +18,12 @@ describe("Button states", () => {
       null
     )
     const button = container.firstChild
-    expect(button).toHaveStyleRule("opacity", "0.4")
-    expect(button).toHaveStyleRule("pointer-events", "none")
+    expect(button).toHaveStyleRule("opacity", "0.4", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("pointer-events", "none", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render loading text", () => {
@@ -53,8 +57,12 @@ describe("Button states", () => {
     )
     const button = container.firstChild
     expect(button).toMatchSnapshot()
-    expect(button).toHaveStyleRule("width", "32px")
-    expect(button).toHaveStyleRule("height", "32px")
+    expect(button).toHaveStyleRule("width", "32px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("height", "32px", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render smaller only icon", () => {
@@ -66,8 +74,12 @@ describe("Button states", () => {
     )
     const button = container.firstChild
     expect(button).toMatchSnapshot()
-    expect(button).toHaveStyleRule("width", "24px")
-    expect(button).toHaveStyleRule("height", "24px")
+    expect(button).toHaveStyleRule("width", "24px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("height", "24px", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render loading icon", () => {
@@ -110,13 +122,27 @@ describe("Default Button", () => {
 
     const button = container.firstChild
     expect(button).toMatchSnapshot()
-    expect(button).toHaveStyleRule("width", "128px")
-    expect(button).toHaveStyleRule("height", "40px")
-    expect(button).toHaveStyleRule("background-color", "#00AB44")
-    expect(button).toHaveStyleRule("border-color", "#00AB44")
-    expect(button).toHaveStyleRule("color", "#FFF")
-    expect(button).toHaveStyleRule("opacity", "1")
-    expect(button).toHaveStyleRule("pointer-events", "auto")
+    expect(button).toHaveStyleRule("width", "128px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("height", "40px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("background-color", "#00AB44", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "#00AB44", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FFF", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("opacity", "1", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("pointer-events", "auto", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render for danger", () => {
@@ -127,9 +153,15 @@ describe("Default Button", () => {
       null
     )
     const button = container.firstChild
-    expect(button).toHaveStyleRule("background-color", "#FF4136")
-    expect(button).toHaveStyleRule("border-color", "#FF4136")
-    expect(button).toHaveStyleRule("color", "#FFF")
+    expect(button).toHaveStyleRule("background-color", "#FF4136", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "#FF4136", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FFF", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render for warning", () => {
@@ -140,9 +172,15 @@ describe("Default Button", () => {
       null
     )
     const button = container.firstChild
-    expect(button).toHaveStyleRule("background-color", "#FFC300")
-    expect(button).toHaveStyleRule("border-color", "#FFC300")
-    expect(button).toHaveStyleRule("color", "#FFF")
+    expect(button).toHaveStyleRule("background-color", "#FFC300", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "#FFC300", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FFF", {
+      modifier: "&&",
+    })
   })
 })
 
@@ -159,13 +197,27 @@ describe("Hollow Button", () => {
 
     const button = container.firstChild
     expect(button).toMatchSnapshot()
-    expect(button).toHaveStyleRule("width", "128px")
-    expect(button).toHaveStyleRule("height", "40px")
-    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("border-color", "#00AB44")
-    expect(button).toHaveStyleRule("color", "#00AB44")
-    expect(button).toHaveStyleRule("opacity", "1")
-    expect(button).toHaveStyleRule("pointer-events", "auto")
+    expect(button).toHaveStyleRule("width", "128px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("height", "40px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "#00AB44", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#00AB44", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("opacity", "1", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("pointer-events", "auto", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render for danger", () => {
@@ -176,9 +228,15 @@ describe("Hollow Button", () => {
       null
     )
     const button = container.firstChild
-    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("border-color", "#FF4136")
-    expect(button).toHaveStyleRule("color", "#FF4136")
+    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "#FF4136", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FF4136", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render for warning", () => {
@@ -189,9 +247,15 @@ describe("Hollow Button", () => {
       null
     )
     const button = container.firstChild
-    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("border-color", "#FFC300")
-    expect(button).toHaveStyleRule("color", "#FFC300")
+    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "#FFC300", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FFC300", {
+      modifier: "&&",
+    })
   })
 })
 
@@ -208,13 +272,27 @@ describe("Borderless Button", () => {
 
     const button = container.firstChild
     expect(button).toMatchSnapshot()
-    expect(button).toHaveStyleRule("width", "128px")
-    expect(button).toHaveStyleRule("height", "40px")
-    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("border-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("color", "#FFF")
-    expect(button).toHaveStyleRule("opacity", "1")
-    expect(button).toHaveStyleRule("pointer-events", "auto")
+    expect(button).toHaveStyleRule("width", "128px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("height", "40px", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FFF", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("opacity", "1", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("pointer-events", "auto", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render for danger", () => {
@@ -225,9 +303,15 @@ describe("Borderless Button", () => {
       null
     )
     const button = container.firstChild
-    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("border-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("color", "#FF4136")
+    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FF4136", {
+      modifier: "&&",
+    })
   })
 
   it(" * should render for warning", () => {
@@ -238,8 +322,14 @@ describe("Borderless Button", () => {
       null
     )
     const button = container.firstChild
-    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("border-color", "rgba(255,255,255,0.0)")
-    expect(button).toHaveStyleRule("color", "#FFC300")
+    expect(button).toHaveStyleRule("background-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("border-color", "rgba(255,255,255,0.0)", {
+      modifier: "&&",
+    })
+    expect(button).toHaveStyleRule("color", "#FFC300", {
+      modifier: "&&",
+    })
   })
 })

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -22,6 +22,7 @@ export interface ButtonProps {
   flavour?: ButtonType
   disabled?: boolean
   small?: boolean
+  [s: string]: any
 }
 
 export interface ButtonWrapperProps extends ButtonProps {

--- a/src/components/button/styled.tsx
+++ b/src/components/button/styled.tsx
@@ -62,81 +62,86 @@ type StyledButtonProps = {
 export const StyledButton = styled.button.attrs((props: ButtonProps) => ({
   colors: colorsByFlavour(props),
 }))<ButtonProps & StyledButtonProps>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
+  && {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
 
-  width: ${props => (props.hasLabel ? getSizeBy(16) : getSizeBy(props.small ? 3 : 4))};
-  height: ${props => (props.hasLabel ? getSizeBy(5) : getSizeBy(props.small ? 3 : 4))};
+    width: ${props => (props.hasLabel ? getSizeBy(16) : getSizeBy(props.small ? 3 : 4))};
+    height: ${props => (props.hasLabel ? getSizeBy(5) : getSizeBy(props.small ? 3 : 4))};
 
-  font-weight: bold;
-  font-size: 12px;
-  line-height: ${getSizeBy(2)};
-  white-space: nowrap;
-  word-break: keep-all;
+    font-weight: bold;
+    font-size: 12px;
+    line-height: ${getSizeBy(2)};
+    white-space: nowrap;
+    word-break: keep-all;
 
-  cursor: pointer;
-  opacity: ${({ disabled }) => (disabled ? 0.4 : 1)};
-  pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
+    cursor: pointer;
+    opacity: ${({ disabled }) => (disabled ? 0.4 : 1)};
+    pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
 
-  padding: ${getSizeBy(1)};
-  transition: all 150ms;
+    padding: ${getSizeBy(1)};
+    transition: all 150ms;
 
-  background-color: ${props => props.colors.bg(props)};
-  color: ${props => props.colors.color(props)};
+    background-color: ${props => props.colors.bg(props)};
+    color: ${props => props.colors.color(props)};
 
-  border-width: 1px;
-  border-style: solid;
-  border-color: ${props => props.colors.border(props)};
-  border-radius: 2px;
-  box-sizing: border-box;
+    border-width: 1px;
+    border-style: solid;
+    border-color: ${props => props.colors.border(props)};
+    border-radius: 2px;
+    box-sizing: border-box;
 
-  &:hover {
-    border-color: ${props => props.colors.borderHover(props)};
-    background-color: ${props => props.colors.bgHover(props)};
-    color: ${props => props.colors.colorHover(props)};
+    text-decoration: none;
+
+    &:hover {
+      border-color: ${props => props.colors.borderHover(props)};
+      background-color: ${props => props.colors.bgHover(props)};
+      color: ${props => props.colors.colorHover(props)};
+      text-decoration: none;
+
+      .button-icon {
+        fill: ${props => props.colors.colorHover(props)};
+      }
+    }
+
+    &:active {
+      border-color: ${props => props.colors.borderActive(props)};
+      background-color: ${props => props.colors.bgActive(props)};
+      color: ${props => props.colors.colorActive(props)};
+    }
+
+    &:focus {
+      outline: none;
+    }
 
     .button-icon {
-      fill: ${props => props.colors.colorHover(props)};
+      position: absolute;
+      left: ${props => (props.hasLabel ? "4px" : "auto")};
+      height: ${getSizeBy(2)};
+      width: ${getSizeBy(2)};
+      fill: ${props => props.colors.color(props)};
     }
-  }
 
-  &:active {
-    border-color: ${props => props.colors.borderActive(props)};
-    background-color: ${props => props.colors.bgActive(props)};
-    color: ${props => props.colors.colorActive(props)};
-  }
+    .ntd-spinner {
+      fill: none;
+      stroke-width: 17px;
+      stroke-dasharray: 100;
+      stroke-dashoffset: 100;
+      animation: ntd-draw 1s linear infinite;
+      stroke: #fff;
+      width: 24px;
+    }
 
-  &:focus {
-    outline: none;
-  }
+    .path {
+      stroke: #fff;
+    }
 
-  .button-icon {
-    position: absolute;
-    left: ${props => (props.hasLabel ? "4px" : "auto")};
-    height: ${getSizeBy(2)};
-    width: ${getSizeBy(2)};
-    fill: ${props => props.colors.color(props)};
-  }
-
-  .ntd-spinner {
-    fill: none;
-    stroke-width: 17px;
-    stroke-dasharray: 100;
-    stroke-dashoffset: 100;
-    animation: ntd-draw 1s linear infinite;
-    stroke: #fff;
-    width: 24px;
-  }
-
-  .path {
-    stroke: #fff;
-  }
-
-  @keyframes ntd-draw {
-    to {
-      stroke-dashoffset: 0;
+    @keyframes ntd-draw {
+      to {
+        stroke-dashoffset: 0;
+      }
     }
   }
 `


### PR DESCRIPTION
- As per styled-components specification, using `as` prop, we should allow the override of the default tag.
- Main usage for this, would be with the router Link component.