### PR TITLE
set overlay z-index with state/ref

### DIFF
--- a/src/components/sidebar/portaled-sidebar.tsx
+++ b/src/components/sidebar/portaled-sidebar.tsx
@@ -1,5 +1,6 @@
-import React, { FC, Fragment, useEffect, ReactNode } from "react"
+import React, { FC, Fragment, useEffect, ReactNode, useState, useRef } from "react"
 import { Portal } from "react-portal"
+import { useMount } from "react-use"
 import { PortalSidebox, DisabledOverlay } from "./styled"
 
 const ESCAPE_KEY = 27
@@ -23,6 +24,9 @@ export const PortalSidebar: FC<PortalSidebarProps> = ({
   right = false,
   Wrapper = Fragment,
 }: PortalSidebarProps) => {
+  const sidebarRef = useRef<HTMLElement>(null)
+  const [overlayZIndex, setOverlayZIndex] = useState("auto")
+
   useEffect(() => {
     const evHandler = (event: KeyboardEvent) => {
       if (event.keyCode === ESCAPE_KEY && closeOnEsc) {
@@ -41,11 +45,25 @@ export const PortalSidebar: FC<PortalSidebarProps> = ({
     }
   }
 
+  useMount(() => {
+    if (sidebarRef?.current) {
+      const element = sidebarRef.current as HTMLElement
+      const style = window.getComputedStyle(element)
+      const zIndex = style.getPropertyValue("z-index") || "auto"
+      setOverlayZIndex(zIndex)
+    }
+  })
+
   return (
     <Portal>
-      <DisabledOverlay onClick={handleOverlayClick} />
+      <DisabledOverlay overlayZIndex={overlayZIndex} onClick={handleOverlayClick} />
       <Wrapper>
-        <PortalSidebox className={className} shadowSide={right} side={right ? "right" : "left"}>
+        <PortalSidebox
+          ref={sidebarRef}
+          className={className}
+          shadowSide={right}
+          side={right ? "right" : "left"}
+        >
           {children}
         </PortalSidebox>
       </Wrapper>

--- a/src/components/sidebar/styled.ts
+++ b/src/components/sidebar/styled.ts
@@ -22,7 +22,7 @@ export const SidebarBox = styled.aside<SidebarBoxT>`
   width: 50%;
 `
 
-export const DisabledOverlay = styled.aside`
+export const DisabledOverlay = styled.aside<{ overlayZIndex: string }>`
   position: absolute;
   top: 0;
   bottom: 0;
@@ -32,6 +32,7 @@ export const DisabledOverlay = styled.aside`
   max-width: 100vw;
   background-color: black;
   opacity: 0.3;
+  z-index: ${({ overlayZIndex }) => overlayZIndex};
 `
 
 export const PortalSidebox = styled.aside<PortalSidebarboxT>`


### PR DESCRIPTION
Earlier, while fixing the styling of portals, we decided to set `className` only for content sidebar, which was helpful for styling it. However, it introduced a bug that app-level `z-index` mixin stopped working for the overlay node.
This solution, while not being most elegant one, offers a way to still set z-index for the overlay while preserving same API / not introducing new props.