### PR TITLE
Tabs support for feature-flagged parts

### DIFF
--- a/src/components/tabs/tabs-hooks.tsx
+++ b/src/components/tabs/tabs-hooks.tsx
@@ -16,14 +16,15 @@ export const useBuildTabs = (
     let activeIsDisabled: boolean = false
 
     Children.forEach(children, (tab, index) => {
-      if (!tab) return
-      const { props } = tab
+      const props = tab?.props || {}
       if (firstActiveIndex < 0 && !props.disabled) firstActiveIndex = index
 
       const isActive = activeIndex === indeces.length
       const key = `${index}-${props.label}`
 
-      nav.push(<Tab key={key} {...props} onChange={onChange} index={index} active={isActive} />)
+      if (tab) {
+        nav.push(<Tab key={key} {...props} onChange={onChange} index={index} active={isActive} />)
+      }
 
       if (isActive) {
         activeIsDisabled = !!props.disabled


### PR DESCRIPTION
In expressions like
```
{isFeatureAvailable() && <Tab ..... />}
```
value `false` will be included in React children array, which messes up useBuildTabs hook, resulting in unreachable feature-flagged tabs, if there are multiple of them and some are enabled and some not.

This PR offers a solution to allow usage of such simple expressions as mentioned above, with persisting indices without actually including "false" part into navs.