### PR TITLE
Resolved aliases after typescript build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "build-storybook": "build-storybook -c .storybook -o public",
     "build": "yarn _drop_native && yarn testOut && build-storybook",
     "clean": "./node_modules/rimraf/bin.js ./lib",
-    "ts-bundle": "yarn _drop_native && yarn clean && tsc && tsc -m es6 && node copy-assets",
+    "ts-bundle": "yarn _drop_native && yarn clean && tsc && tsc -m es6 && node copy-assets && yarn resolveAlias",
     "test": "jest --config ./jest/config.js",
-    "prepare": "install-peers && yarn ts-bundle"
+    "prepare": "install-peers && yarn ts-bundle",
+    "resolveAlias": "tscpaths -p tsconfig.json -s ./src -o ./lib"
   },
   "keywords": [
     "uikit",
@@ -95,6 +96,7 @@
     "svgo": "^1.3.0",
     "svgo-loader": "^2.2.1",
     "ts-jest": "^26.4.4",
+    "tscpaths": "^0.0.9",
     "typescript": "^4.0.5",
     "url-loader": "^4.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13562,6 +13562,14 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tscpaths@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/tscpaths/-/tscpaths-0.0.9.tgz#c77abfde6820920f10c64f83c27753b9505814ab"
+  integrity sha512-tz4qimSJTCjYtHVsoY7pvxLcxhmhgmwzm7fyMEiL3/kPFFVyUuZOwuwcWwjkAsIrSUKJK22A7fNuJUwxzQ+H+w==
+  dependencies:
+    commander "^2.20.0"
+    globby "^9.2.0"
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"


### PR DESCRIPTION
**Before**
The emitted files in the `lib` where resolved with the alias path, so the clients could not import them.

**After** 
The emitted files contain the relative paths.