### PR TITLE
fix react child-as-fn warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/collapsible/index.js
+++ b/src/components/collapsible/index.js
@@ -51,7 +51,7 @@ const Collapsible = forwardRef(
     }, [open])
 
     const child = useMemo(
-      () => ((animatedOpen || persist) && typeof children === "function" ? children() : children),
+      () => (animatedOpen || persist) && (typeof children === "function" ? children() : children),
       [animatedOpen, persist, children]
     )
 


### PR DESCRIPTION
fix react warning when collapsible's children are trying to render as function