### PR TITLE
Updated mouse event that triggers tooltip to open.

### DIFF
--- a/src/components/drops/tooltip/index.js
+++ b/src/components/drops/tooltip/index.js
@@ -29,7 +29,7 @@ const Tooltip = forwardRef(
     const [ref, setRef] = useForwardRef(parentRef)
 
     const targetElement = useClonedChildren(children, setRef, {
-      onMouseOver: open,
+      onMouseEnter: open,
       onMouseLeave: close,
       onFocus: open,
       onBlur: close,


### PR DESCRIPTION
- Bubbling phase of onMouseOver was conflicting with the onMouseLeave causing unnecessary back-and-forth on isOpen.