### PR TITLE
UI/update buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.7.20",
+  "version": "1.7.21",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.7.19",
+  "version": "1.7.20",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/button/__snapshots__/button.test.js.snap
+++ b/src/components/button/__snapshots__/button.test.js.snap
@@ -71,7 +71,7 @@ exports[`Borderless Button  * should render 1`] = `
 
 .c0.c0 .button-icon {
   position: absolute;
-  left: 4px;
+  left: 8px;
   height: 16px;
   width: 16px;
   fill: #00AB44;
@@ -172,7 +172,7 @@ exports[`Button states  * should render loading icon 1`] = `
 
 .c0.c0 .button-icon {
   position: absolute;
-  left: 4px;
+  left: 8px;
   height: 16px;
   width: 16px;
   fill: #FFF;
@@ -534,7 +534,7 @@ exports[`Default Button  * should render 1`] = `
 
 .c0.c0 .button-icon {
   position: absolute;
-  left: 4px;
+  left: 8px;
   height: 16px;
   width: 16px;
   fill: #FFF;
@@ -635,7 +635,7 @@ exports[`Hollow Button  * should render 1`] = `
 
 .c0.c0 .button-icon {
   position: absolute;
-  left: 4px;
+  left: 8px;
   height: 16px;
   width: 16px;
   fill: #00AB44;

--- a/src/components/button/__snapshots__/button.test.js.snap
+++ b/src/components/button/__snapshots__/button.test.js.snap
@@ -39,6 +39,14 @@ exports[`Borderless Button  * should render 1`] = `
   text-decoration: none;
 }
 
+.c0.c0 > span {
+  text-transform: lowercase;
+}
+
+.c0.c0 > span::first-letter {
+  text-transform: uppercase;
+}
+
 .c0.c0:hover {
   border-color: rgba(255,255,255,0.0);
   background-color: rgba(255,255,255,0.0);
@@ -130,6 +138,14 @@ exports[`Button states  * should render loading icon 1`] = `
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.c0.c0 > span {
+  text-transform: lowercase;
+}
+
+.c0.c0 > span::first-letter {
+  text-transform: uppercase;
 }
 
 .c0.c0:hover {
@@ -260,6 +276,14 @@ exports[`Button states  * should render only icon 1`] = `
   text-decoration: none;
 }
 
+.c0.c0 > span {
+  text-transform: lowercase;
+}
+
+.c0.c0 > span::first-letter {
+  text-transform: uppercase;
+}
+
 .c0.c0:hover {
   border-color: #42b861;
   background-color: rgba(255,255,255,0.0);
@@ -363,6 +387,14 @@ exports[`Button states  * should render smaller only icon 1`] = `
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.c0.c0 > span {
+  text-transform: lowercase;
+}
+
+.c0.c0 > span::first-letter {
+  text-transform: uppercase;
 }
 
 .c0.c0:hover {
@@ -470,6 +502,14 @@ exports[`Default Button  * should render 1`] = `
   text-decoration: none;
 }
 
+.c0.c0 > span {
+  text-transform: lowercase;
+}
+
+.c0.c0 > span::first-letter {
+  text-transform: uppercase;
+}
+
 .c0.c0:hover {
   border-color: #42b861;
   background-color: #00AB44;
@@ -561,6 +601,14 @@ exports[`Hollow Button  * should render 1`] = `
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.c0.c0 > span {
+  text-transform: lowercase;
+}
+
+.c0.c0 > span::first-letter {
+  text-transform: uppercase;
 }
 
 .c0.c0:hover {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -4,9 +4,23 @@ import { Icon } from "src/components/icon"
 import { LoaderIcon } from "src/components/icon/components"
 
 export const Button = forwardRef(
-  ({ label, icon, flavour, isLoading, loadingLabel, loadingIcon, onClick, ...rest }, ref) => (
+  (
+    {
+      label,
+      icon,
+      flavour,
+      isLoading,
+      loadingLabel,
+      loadingIcon,
+      onClick,
+      textTransform = "firstLetter",
+      ...rest
+    },
+    ref
+  ) => (
     <StyledButton
       flavour={flavour}
+      textTransform={textTransform}
       hasLabel={!!label}
       onClick={isLoading ? undefined : onClick}
       ref={ref}

--- a/src/components/button/button.test.js
+++ b/src/components/button/button.test.js
@@ -17,11 +17,77 @@ describe("Button states", () => {
     })
   })
 
-  it(" * should render with uppercase", () => {
-    const { container } = renderWithProviders(<Button label="Test prop text" uppercase />)
+  it(" * should render a button with text being in default format", () => {
+    const { container } = renderWithProviders(<Button label="Test prop text" />)
+    const button = container.firstChild
+    expect(button).toHaveStyleRule("text-transform", "lowercase", {
+      modifier: "&& > span",
+    })
+    expect(button).toHaveStyleRule("text-transform", "uppercase", {
+      modifier: "&& > span::first-letter",
+    })
+  })
+
+  it(" * should render a button with text that has no text-transform", () => {
+    const { container } = renderWithProviders(
+      <Button label="Test prop text" textTransform="none" />
+    )
+    const button = container.firstChild
+    expect(button).toHaveStyleRule("text-transform", "none", {
+      modifier: "&& > span",
+    })
+  })
+
+  it(" * should render a button with text being capitalized", () => {
+    const { container } = renderWithProviders(
+      <Button label="Test prop text" textTransform="capitalize" />
+    )
+    const button = container.firstChild
+    expect(button).toHaveStyleRule("text-transform", "capitalize", {
+      modifier: "&& > span",
+    })
+  })
+
+  it(" * should render a button with text being in uppercase", () => {
+    const { container } = renderWithProviders(
+      <Button label="Test prop text" textTransform="uppercase" />
+    )
     const button = container.firstChild
     expect(button).toHaveStyleRule("text-transform", "uppercase", {
-      modifier: "&&",
+      modifier: "&& > span",
+    })
+  })
+
+  it(" * should render a button with text being in lowercase", () => {
+    const { container } = renderWithProviders(
+      <Button label="Test prop text" textTransform="lowercase" />
+    )
+    const button = container.firstChild
+    expect(button).toHaveStyleRule("text-transform", "lowercase", {
+      modifier: "&& > span",
+    })
+  })
+
+  it(" * should render a button with text being in full-width", () => {
+    const { container } = renderWithProviders(
+      <Button label="Test prop text" textTransform="fullWidth" />
+    )
+    const button = container.firstChild
+    expect(button).toHaveStyleRule("text-transform", "full-width", {
+      modifier: "&& > span",
+    })
+  })
+
+  it(" * should render a text with only one capital letter, the first one", () => {
+    const { container } = renderWithProviders(
+      <Button label="Test prop text" textTransform="firstLetter" />
+    )
+    const button = container.firstChild
+    expect(button).toHaveStyleRule("text-transform", "lowercase", {
+      modifier: "&& > span",
+    })
+    expect(button).toHaveStyleRule("text-transform", "uppercase", {
+      modifier: "&& > span::first-letter",
     })
   })
 

--- a/src/components/button/styled.js
+++ b/src/components/button/styled.js
@@ -3,6 +3,7 @@ import { getColor, getSizeBy, DefaultTheme, DarkTheme } from "src/theme"
 import margin from "src/mixins/margin"
 import padding from "src/mixins/padding"
 import alignSelf from "src/mixins/alignSelf"
+import textTransform from "src/mixins/textTransform"
 import { DEFAULT, HOLLOW, BORDER_LESS } from "./constants"
 
 const themes = {
@@ -128,7 +129,9 @@ export const StyledButton = styled.button.attrs(props => ({
     box-sizing: border-box;
 
     text-decoration: none;
-    ${props => props.uppercase && "text-transform: uppercase;"}
+    & > span {
+      ${textTransform}
+    }
 
     &:hover {
       border-color: ${props => props.colors.borderHover(props)};

--- a/src/components/button/styled.js
+++ b/src/components/button/styled.js
@@ -159,7 +159,7 @@ export const StyledButton = styled.button.attrs(props => ({
 
     .button-icon {
       position: absolute;
-      left: ${props => (props.hasLabel ? "4px" : "auto")};
+      left: ${props => (props.hasLabel ? "8px" : "auto")};
       height: ${getSizeBy(2)};
       width: ${getSizeBy(2)};
       fill: ${props => props.colors.color(props)};

--- a/src/mixins/textTransform.js
+++ b/src/mixins/textTransform.js
@@ -7,11 +7,11 @@ const textTransformMap = {
   fullWidth: "full-width",
 }
 
-const textTransform = ({ textTransform }) => {
+const textTransform = ({ textTransform = "none" } = {}) => {
   if (textTransform === textTransformMap.firstLetter)
     return `text-transform: lowercase;
     &::first-letter {
-      text-transform: uppercase
+      text-transform: uppercase;
     }
 `
   return textTransform in textTransformMap

--- a/src/mixins/textTransform.js
+++ b/src/mixins/textTransform.js
@@ -1,0 +1,22 @@
+const textTransformMap = {
+  none: "none",
+  capitalize: "capitalize",
+  uppercase: "uppercase",
+  lowercase: "lowercase",
+  firstLetter: "firstLetter",
+  fullWidth: "full-width",
+}
+
+const textTransform = ({ textTransform }) => {
+  if (textTransform === textTransformMap.firstLetter)
+    return `text-transform: lowercase;
+    &::first-letter {
+      text-transform: uppercase
+    }
+`
+  return textTransform in textTransformMap
+    ? `text-transform: ${textTransformMap[textTransform]};`
+    : `text-transform: ${textTransformMap.none};`
+}
+
+export default textTransform

--- a/src/mixins/textTransform.test.js
+++ b/src/mixins/textTransform.test.js
@@ -1,0 +1,29 @@
+import textTransform from "./textTransform"
+
+it("returns the default state", () => {
+  expect(textTransform()).toBe("text-transform: none;")
+})
+
+it("returns text-transform: uppercase", () => {
+  expect(textTransform({ textTransform: "uppercase" })).toBe("text-transform: uppercase;")
+})
+
+it("returns text-transform: lowercase", () => {
+  expect(textTransform({ textTransform: "lowercase" })).toBe("text-transform: lowercase;")
+})
+
+it("returns text-transform: capitalize", () => {
+  expect(textTransform({ textTransform: "capitalize" })).toBe("text-transform: capitalize;")
+})
+
+it("returns text-transform: full-width", () => {
+  expect(textTransform({ textTransform: "fullWidth" })).toBe("text-transform: full-width;")
+})
+
+it("returns text-transform rule with lowercase value and then it transforms only the first letter of the text to uppercase", () => {
+  expect(textTransform({ textTransform: "firstLetter" })).toBe(`text-transform: lowercase;
+    &::first-letter {
+      text-transform: uppercase;
+    }
+`)
+})


### PR DESCRIPTION
https://app.zenhub.com/workspaces/product-5ea1534e9ff5df7daace00d5/issues/netdata/product/2294

- Update all buttons labels
- All button labels should be `First letter only in capital` in default state . The transformation happens through a mixin called textTransform.
- For consistency, when you add a button with a label, keep this casing on the text. `Add example`