### PR TITLE
chore: add colors for informative node badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.7.32",
+  "version": "1.7.33",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/icon/icons-list.js
+++ b/src/components/icon/icons-list.js
@@ -123,7 +123,7 @@ import osLinuxColor from "./assets/os/linux_color.svg"
 import osMacOSX from "./assets/os/macOSX.svg"
 import osOracle from "./assets/os/oracle.svg"
 import osOracleColor from "./assets/os/oracle_color.svg"
-import osOsPress from "./assets/os/os_press.svg"
+import osPress from "./assets/os/os_press.svg"
 import osRaspbian from "./assets/os/raspbian.svg"
 import osRedHat from "./assets/os/red_hat.svg"
 import osSuseLinux from "./assets/os/suse_linux.svg"
@@ -368,7 +368,7 @@ export const iconsList = {
   osMacOSX,
   osOracle,
   osOracleColor,
-  osOsPress,
+  osPress,
   osRaspbian,
   osRedHat,
   osSuseLinux,

--- a/src/theme/dark/colors.js
+++ b/src/theme/dark/colors.js
@@ -48,6 +48,10 @@ const appColors = {
   inputBorder: rawColors.neutral.bluebayoux,
   inputBorderHover: rawColors.neutral.white,
   inputBorderFocus: rawColors.neutral.white,
+  // Badges
+  nodeBadgeBackground: rawColors.neutral.limedSpruce,
+  nodeBadgeBorder: rawColors.neutral.iron,
+  nodeBadgeColor: rawColors.neutral.white,
 }
 
 export default {

--- a/src/theme/default/colors.js
+++ b/src/theme/default/colors.js
@@ -48,6 +48,10 @@ const appColors = {
   inputBorder: rawColors.neutral.iron,
   inputBorderHover: rawColors.neutral.regentgrey,
   inputBorderFocus: rawColors.neutral.bluebayoux,
+  // Badges
+  nodeBadgeBackground: rawColors.neutral.porcelain,
+  nodeBadgeBorder: rawColors.neutral.iron,
+  nodeBadgeColor: rawColors.neutral.bluebayoux,
 }
 
 export default {


### PR DESCRIPTION
This PR adds a set of colors for the pills used as badges in node views of cloud app.