### PR TITLE
chore(MasterCard): add single onClick support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.7.33",
+  "version": "1.7.34",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/pill/mastercard.js
+++ b/src/components/pill/mastercard.js
@@ -1,10 +1,8 @@
-import React, {forwardRef} from "react"
+import React, { forwardRef } from "react"
 import Flex from "src/components/templates/flex";
 import Pill from "./index"
-import {getMasterCardColor, getPillColor} from "./mixins/colors"
-import getPillHeight from "./mixins/height";
-import Container from "src/components/pill/container";
-import PillIcon from "src/components/pill/icon";
+import { getMasterCardColor } from "./mixins/colors"
+import { MasterCardContainer } from "./styled"
 
 const minWidths = {
   default: "29px",
@@ -21,6 +19,7 @@ const MasterCard = forwardRef(
     flavours = ["neutralGrey", "neutralIron"],
     height,
     normal,
+    onClick,
     onClicks,
     refs,
     round,
@@ -28,16 +27,21 @@ const MasterCard = forwardRef(
     texts,
     ...rest
   }, ref) => (
-    <Flex
+    <MasterCardContainer
       background={getBackground(backgrounds?.[1], flavours?.[1] || "neutralIron")}
-      height={getPillHeight(height, size)}
-      round={round || 999}
+      height={height}
+      onClick={onClick}
+      round={round}
       size={size}
       ref={ref}
     >
       {flavours.map((flavour, index) => {
         const elementFlavour = flavour || (index === 0 ? "neutralGrey" : "neutralIron")
         const background = getBackground(backgrounds?.[index], elementFlavour)
+        const pillProps = {
+          ...rest,
+          ...(!onClick && { onClick: onClicks?.[index] })
+        }
 
         return (
           <Pill
@@ -50,19 +54,18 @@ const MasterCard = forwardRef(
             key={`${elementFlavour}_${index}`}
             marginLeft={index === 1 && "-4px"}
             normal={normal}
-            onClick={onClicks?.[index]}
             position={index === 0 && "relative"}
             ref={refs?.[index]}
             round={round}
             size={size}
             width={index === 0 && { min: minWidths[size] || minWidths.default }}
             padding={index === 0 ? [1, 3] : [1, 2]}
-            {...rest}>
+            {...pillProps}>
             {texts?.[index] || "-"}
           </Pill>
         )
       })}
-    </Flex>
+    </MasterCardContainer>
   )
 )
 

--- a/src/components/pill/mastercard.js
+++ b/src/components/pill/mastercard.js
@@ -1,5 +1,4 @@
 import React, { forwardRef } from "react"
-import Flex from "src/components/templates/flex";
 import Pill from "./index"
 import { getMasterCardColor } from "./mixins/colors"
 import { MasterCardContainer } from "./styled"

--- a/src/components/pill/styled.js
+++ b/src/components/pill/styled.js
@@ -1,0 +1,17 @@
+import styled from "styled-components"
+import Flex from "src/components/templates/flex"
+import getPillHeight from "src/components/pill/mixins/height";
+
+export const MasterCardContainer = styled(Flex).attrs(
+  ({ background, height, onClick, round = 999, size }) => ({
+    background,
+    height: getPillHeight(height, size),
+    cursor: onClick ? "pointer" : "default",
+    round,
+    size,
+  })
+)`
+  > * {
+    ${({ onClick }) => (onClick && "cursor: pointer;")}
+  }
+`

--- a/src/theme/dark/colors.js
+++ b/src/theme/dark/colors.js
@@ -50,7 +50,7 @@ const appColors = {
   inputBorderFocus: rawColors.neutral.white,
   // Badges
   nodeBadgeBackground: rawColors.neutral.limedSpruce,
-  nodeBadgeBorder: rawColors.neutral.iron,
+  nodeBadgeBorder: rawColors.neutral.bluebayoux,
   nodeBadgeColor: rawColors.neutral.white,
 }
 


### PR DESCRIPTION
This PR includes the following updates:
* Add support on `MasterCard` component for single `onClick` functionality
* Fixes border color of node badges in dark theme

#### Notes
When alerts tab is implemented in **NetData Cloud**, `MasterCard` component will support only a single click that will open the right sidebar will alerts tab selected