### PR TITLE
Fix double opening dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.7.44",
+  "version": "1.7.45",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/drops/drop/index.js
+++ b/src/components/drops/drop/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, forwardRef } from "react"
+import React, { forwardRef, useEffect } from "react"
 import ReactDOM from "react-dom"
 import useDropElement from "src/hooks/use-drop-element"
 import useKeyboardEsc from "src/hooks/use-keyboard-esc"
@@ -35,7 +35,7 @@ const Drop = forwardRef(
 
     useDimensionChange(target, updatePosition)
 
-    useOutsideClick(ref, onClickOutside)
+    useOutsideClick(ref, onClickOutside, target)
     useKeyboardEsc(onEsc)
 
     const el = useDropElement()

--- a/src/components/drops/mixins/isAncestor.js
+++ b/src/components/drops/mixins/isAncestor.js
@@ -1,0 +1,3 @@
+import getAncestors from "./getAncestors"
+
+export default (parent, target) => getAncestors(target).some(node => node === parent)

--- a/src/hooks/use-outside-click/index.js
+++ b/src/hooks/use-outside-click/index.js
@@ -1,14 +1,14 @@
 import { useEffect } from "react"
-import getAncestors from "src/components/drops/mixins/getAncestors"
+import isAncestor from "src/components/drops/mixins/isAncestor"
 
-export default (targetRef, onClickOutside) =>
+export default (dropRef, onClickOutside) => {
   useEffect(() => {
     if (!onClickOutside) return
 
     const onMousedown = event => {
       if (
-        event.target !== targetRef.current &&
-        !getAncestors(event.target).some(node => node === targetRef.current)
+        event.target !== dropRef.current &&
+        !isAncestor(dropRef.current, event.target)
       ) {
         onClickOutside(event)
       }
@@ -17,3 +17,4 @@ export default (targetRef, onClickOutside) =>
     document.addEventListener("mousedown", onMousedown)
     return () => document.removeEventListener("mousedown", onMousedown)
   }, [onClickOutside])
+}

--- a/src/hooks/use-outside-click/index.js
+++ b/src/hooks/use-outside-click/index.js
@@ -1,14 +1,17 @@
 import { useEffect } from "react"
 import isAncestor from "src/components/drops/mixins/isAncestor"
 
-export default (dropRef, onClickOutside) => {
+export default (dropRef, onClickOutside, target) => {
   useEffect(() => {
     if (!onClickOutside) return
 
     const onMousedown = event => {
       if (
         event.target !== dropRef.current &&
-        !isAncestor(dropRef.current, event.target)
+        // dont fire when clicking in drop
+        !isAncestor(dropRef.current, event.target) &&
+        // dont fire when clicking dropdown-button
+        !isAncestor(target, event.target)
       ) {
         onClickOutside(event)
       }


### PR DESCRIPTION
related to https://github.com/netdata/cloud-frontend/issues/2877

When dropdown is opened and user clicks on dropdown-button (here: `target`), `onClickOutside` captures mousedown which closes the dropdown, and then `click` is captured separately which opens it again.

I added a detection if mousedown was done in dropdown-button, if yes, `onClickOutside` will not trigger.
This will fix dropdown buttons and btw. maybe it will allow us to remove some rmwc buttons