### PR TITLE
Add test coverage report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,65 @@
+---
+name: tests
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+    inputs:
+concurrency:
+  group: netdata-ui-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.22.0"
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run Tests
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        id: run-tests
+        run: yarn test --coverage --collectCoverageFrom="./src/**" > /tmp/coverage_report
+
+      - name: Post Test Coverage Report in PR
+        uses: ArtiomTr/jest-coverage-report-action@v2
+        continue-on-error: true
+        if: github.event_name == 'pull_request'
+        with:
+          test-script: yarn test --collectCoverageFrom="./src/**"
+          annotations: all
+
+      - name: Gain access to test-reports bucket
+        if: (steps.run-tests.outcome == 'failure' || steps.run-tests.outcome == 'success') && github.ref == 'refs/heads/develop'
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: "netdata-cloud-testing"
+          service_account_key: ${{ secrets.TEST_AUTOMATION_SERVICE_ACCOUNT }}
+          export_default_credentials: true
+
+      - name: Upload report to test-reports bucket
+        if: (steps.run-tests.outcome == 'failure' || steps.run-tests.outcome == 'success') && github.ref == 'refs/heads/develop'
+        run: |
+          gsutil -h "Cache-Control: max-age=0, no-store" cp /tmp/coverage_report gs://${{ secrets.TEST_AUTOMATION_STORAGE_BUCKET }}/${{ github.event.repository.name }}/coverage_report
+          gsutil acl set project-private gs://${{ secrets.TEST_AUTOMATION_STORAGE_BUCKET }}/${{ github.event.repository.name }}/coverage_report
+
+      - name: Publish test coverage report
+        if: (steps.run-tests.outcome == 'failure' || steps.run-tests.outcome == 'success') && github.ref == 'refs/heads/develop'
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with:
+          repo: netdata/cloud-workflows
+          ref: refs/heads/main
+          workflow: test_coverage_publisher.yml
+          token: ${{ secrets.TEST_AUTOMATION_TOKEN }}
+          inputs: '{ "service-name": "${{ github.event.repository.name }}"}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@
 name: tests
 
 on:
-  pull_request:
   push:
+    branches: [master]
   workflow_dispatch:
-    inputs:
+
 concurrency:
-  group: netdata-ui-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.22.0"
+          node-version: "12.x"
           cache: "yarn"
       - name: Install dependencies
         run: yarn
@@ -51,7 +51,8 @@ jobs:
       - name: Upload report to test-reports bucket
         if: (steps.run-tests.outcome == 'failure' || steps.run-tests.outcome == 'success') && github.ref == 'refs/heads/develop'
         run: |
-          gsutil -h "Cache-Control: max-age=0, no-store" cp /tmp/coverage_report gs://${{ secrets.TEST_AUTOMATION_STORAGE_BUCKET }}/${{ github.event.repository.name }}/coverage_report
+          gsutil -h "Cache-Control: max-age=0, no-store" cp \
+          /tmp/coverage_report gs://${{ secrets.TEST_AUTOMATION_STORAGE_BUCKET }}/${{ github.event.repository.name }}/coverage_report
           gsutil acl set project-private gs://${{ secrets.TEST_AUTOMATION_STORAGE_BUCKET }}/${{ github.event.repository.name }}/coverage_report
 
       - name: Publish test coverage report


### PR DESCRIPTION
Added similar test-coverage report as we have in "cound-frontend"

So from now on, all tests will be executed when a pull request is being created.

And we will publish the results into google cloud, so we can check the current status [here](https://github.com/netdata/test-automation/wiki/Netdata-Test-Coverage-Report)

Could you please check this change? And if you have any concerns let me know