### PR TITLE
add: space-evenly option to justify-content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/templates/mixins/index.d.ts
+++ b/src/components/templates/mixins/index.d.ts
@@ -39,7 +39,7 @@ export interface HeightProps {
 }
 
 export interface JustifyContentProps {
-  justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch"
+  justifyContent?: "start" | "center" | "end" | "between" | "evenly" | "around" | "stretch"
 }
 
 export interface OverflowProps {

--- a/src/components/templates/mixins/justifyContent.js
+++ b/src/components/templates/mixins/justifyContent.js
@@ -4,6 +4,7 @@ const justifyContentMap = {
   end: "flex-end",
   between: "space-between",
   around: "space-around",
+  evenly: "space-evenly",
   stretch: "stretch",
 }
 


### PR DESCRIPTION
This adds the missing "space-evenly" option on the justify-content Flex attribute.