### PR TITLE
chore: add netdata press icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/icon/assets/netdata-press.svg
+++ b/src/components/icon/assets/netdata-press.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M10.535 2H0.157959L7.46896 16H11.036C14.792 16 17.836 12.983 17.842 9.254C17.84 5.251 14.571 2.007 10.535 2Z" />
+</svg>

--- a/src/components/icon/icons-list.js
+++ b/src/components/icon/icons-list.js
@@ -100,6 +100,7 @@ import navRight from "./assets/nav_right.svg"
 import nav_arrow_goto from "./assets/nav_arrow_goto.svg"
 import nav_dots from "./assets/nav_dots.svg"
 import netdata from "./assets/netdata.svg"
+import netdataPress from "./assets/netdata-press.svg"
 import node from "./assets/node.svg"
 import node_child from "./assets/node_child.svg"
 import node_default_l from "./assets/node_default_l.svg"
@@ -359,6 +360,7 @@ export const iconsList = {
   nav_dots,
   networkingStack,
   netdata,
+  netdataPress,
   node,
   node_child,
   node_default_l,


### PR DESCRIPTION
This PR is required for the implementation of [Cloud Frontend #3126](https://github.com/netdata/cloud-frontend/issues/3126)

#### Solution
Add `netdataPress` logo in icons list

Please note that the already existing `logo_s`, as @vinnygats mentioned, stretches