### PR TITLE
add highlight area icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.9.17",
+  "version": "1.10.0",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/icon/assets/highlight_area.svg
+++ b/src/components/icon/assets/highlight_area.svg
@@ -1,0 +1,17 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_3271_101161)">
+<path d="M10 13L12 13L12 15L13 15L13 13L15 13L15 12L13 12L13 10L12 10L12 12L10 12L10 13Z" fill="#8F9EAA"/>
+<path d="M6 13L8 13L8 12L6 12L6 13Z" fill="#8F9EAA"/>
+<path d="M4 13L4 12L2 12L2 10L1 10L1 12C1 12.2652 1.10536 12.5196 1.29289 12.7071C1.48043 12.8946 1.73478 13 2 13L4 13Z" fill="#8F9EAA"/>
+<path d="M12 8L13 8L13 6L12 6L12 8Z" fill="#8F9EAA"/>
+<path d="M12 2L12 4L13 4L13 2C13 1.73478 12.8946 1.48043 12.7071 1.29289C12.5196 1.10536 12.2652 1 12 1L10 1L10 2L12 2Z" fill="#8F9EAA"/>
+<path d="M1 8L2 8L2 6L1 6L1 8Z" fill="#8F9EAA"/>
+<path d="M6 2L8 2L8 1L6 1L6 2Z" fill="#8F9EAA"/>
+<path d="M2 4L2 2L4 2L4 1L2 1C1.73478 1 1.48043 1.10536 1.29289 1.29289C1.10536 1.48043 1 1.73478 1 2L1 4L2 4Z" fill="#8F9EAA"/>
+</g>
+<defs>
+<clipPath id="clip0_3271_101161">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/icon/assets/highlight_area.svg
+++ b/src/components/icon/assets/highlight_area.svg
@@ -1,17 +1,18 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_3271_101161)">
-<path d="M10 13L12 13L12 15L13 15L13 13L15 13L15 12L13 12L13 10L12 10L12 12L10 12L10 13Z" fill="#8F9EAA"/>
-<path d="M6 13L8 13L8 12L6 12L6 13Z" fill="#8F9EAA"/>
-<path d="M4 13L4 12L2 12L2 10L1 10L1 12C1 12.2652 1.10536 12.5196 1.29289 12.7071C1.48043 12.8946 1.73478 13 2 13L4 13Z" fill="#8F9EAA"/>
-<path d="M12 8L13 8L13 6L12 6L12 8Z" fill="#8F9EAA"/>
-<path d="M12 2L12 4L13 4L13 2C13 1.73478 12.8946 1.48043 12.7071 1.29289C12.5196 1.10536 12.2652 1 12 1L10 1L10 2L12 2Z" fill="#8F9EAA"/>
-<path d="M1 8L2 8L2 6L1 6L1 8Z" fill="#8F9EAA"/>
-<path d="M6 2L8 2L8 1L6 1L6 2Z" fill="#8F9EAA"/>
-<path d="M2 4L2 2L4 2L4 1L2 1C1.73478 1 1.48043 1.10536 1.29289 1.29289C1.10536 1.48043 1 1.73478 1 2L1 4L2 4Z" fill="#8F9EAA"/>
-</g>
-<defs>
-<clipPath id="clip0_3271_101161">
-<rect width="16" height="16" fill="white"/>
-</clipPath>
-</defs>
+<svg width="16" height="16" viewBox="0 0 16 16"
+  xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_3271_101161)">
+    <path d="M10 13L12 13L12 15L13 15L13 13L15 13L15 12L13 12L13 10L12 10L12 12L10 12L10 13Z" />
+    <path d="M6 13L8 13L8 12L6 12L6 13Z" />
+    <path d="M4 13L4 12L2 12L2 10L1 10L1 12C1 12.2652 1.10536 12.5196 1.29289 12.7071C1.48043 12.8946 1.73478 13 2 13L4 13Z" />
+    <path d="M12 8L13 8L13 6L12 6L12 8Z" />
+    <path d="M12 2L12 4L13 4L13 2C13 1.73478 12.8946 1.48043 12.7071 1.29289C12.5196 1.10536 12.2652 1 12 1L10 1L10 2L12 2Z" />
+    <path d="M1 8L2 8L2 6L1 6L1 8Z" />
+    <path d="M6 2L8 2L8 1L6 1L6 2Z" />
+    <path d="M2 4L2 2L4 2L4 1L2 1C1.73478 1 1.48043 1.10536 1.29289 1.29289C1.10536 1.48043 1 1.73478 1 2L1 4L2 4Z" />
+  </g>
+  <defs>
+    <clipPath id="clip0_3271_101161">
+      <rect width="16" height="16" />
+    </clipPath>
+  </defs>
 </svg>

--- a/src/components/icon/icons-list.js
+++ b/src/components/icon/icons-list.js
@@ -84,6 +84,7 @@ import group_by from "./assets/group_by.svg"
 import hamburger from "./assets/hamburger.svg"
 import help from "./assets/help.svg"
 import hide from "./assets/hide.svg"
+import highlight_area from "./assets/highlight_area.svg"
 import holder from "./assets/holder.svg"
 import information from "./assets/information.svg"
 import informationPress from "./assets/information_press.svg"
@@ -347,6 +348,7 @@ export const iconsList = {
   hamburger,
   help,
   hide,
+  highlight_area,
   holder,
   information,
   informationPress,

--- a/src/components/icon/icons-list.js
+++ b/src/components/icon/icons-list.js
@@ -84,7 +84,7 @@ import group_by from "./assets/group_by.svg"
 import hamburger from "./assets/hamburger.svg"
 import help from "./assets/help.svg"
 import hide from "./assets/hide.svg"
-import highlight_area from "./assets/highlight_area.svg"
+import highlightArea from "./assets/highlight_area.svg"
 import holder from "./assets/holder.svg"
 import information from "./assets/information.svg"
 import informationPress from "./assets/information_press.svg"
@@ -348,7 +348,7 @@ export const iconsList = {
   hamburger,
   help,
   hide,
-  highlight_area,
+  highlightArea,
   holder,
   information,
   informationPress,


### PR DESCRIPTION
Add highlight area icon to assets
To be used in Anomalies tab as indication to action.

Developer insight:
There already is the `selected_area.svg` icon, but there is also a `services/selected_area.svg`, which has the same name but is in a different folder. Regardless, it seems that trying to export both results in one of them being overwritten because they have the same name. The `charts` repo bypasses this by directly importing the svg file and rendering it as a `<svg />` element instead of a `<Icon />` component.
Since the agreed convention is to use the `<Icon />` component wherever possible, this is being added as a replacement of the old `selected_area.svg` and an issue for `charts` will be opened to use this instead.