### PR TITLE
chore: add TS declaration files for components & hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,9 @@ module.exports = {
   overrides: [
     {
       files: ["*.ts", "*.tsx"],
+      globals: {
+        JSX: true,
+      },
       parser: "@typescript-eslint/parser",
       plugins: ["@typescript-eslint"],
       parserOptions: {

--- a/copy-assets.js
+++ b/copy-assets.js
@@ -31,6 +31,8 @@ copyFileSync("src/components/drops/tooltip/index.d.ts", "lib/components/drops/to
 copyFileSync("src/components/drops/popover/index.d.ts", "lib/components/drops/popover/index.d.ts")
 copyFileSync("src/components/icon/index.d.ts", "lib/components/icon/index.d.ts")
 copyFileSync("src/components/input/input.d.ts", "lib/components/input/input.d.ts")
+copyFileSync("src/components/input/use-input-value.d.ts", "lib/components/input/use-input-value.d.ts")
+copyFileSync("src/components/input/use-touched-state.d.ts", "lib/components/input/use-touched-state.d.ts")
 copyFileSync("src/components/pill/index.d.ts", "lib/components/pill/index.d.ts")
 copyFileSync("src/components/pill/alertMastercard.d.ts", "lib/components/pill/alertMastercard.d.ts")
 copyFileSync("src/components/pill/mastercard.d.ts", "lib/components/pill/mastercard.d.ts")

--- a/copy-assets.js
+++ b/copy-assets.js
@@ -36,6 +36,7 @@ copyFileSync("src/components/input/use-touched-state.d.ts", "lib/components/inpu
 copyFileSync("src/components/pill/index.d.ts", "lib/components/pill/index.d.ts")
 copyFileSync("src/components/pill/alertMastercard.d.ts", "lib/components/pill/alertMastercard.d.ts")
 copyFileSync("src/components/pill/mastercard.d.ts", "lib/components/pill/mastercard.d.ts")
+copyFileSync("src/components/sidebar/portaled-sidebar.d.ts", "lib/components/sidebar/portaled-sidebar.d.ts")
 
 copyFileSync("src/components/collapsible/index.d.ts", "lib/components/collapsible/index.d.ts")
 copyFileSync("src/components/modal/index.d.ts", "lib/components/modal/index.d.ts")

--- a/copy-assets.js
+++ b/copy-assets.js
@@ -39,6 +39,7 @@ copyFileSync("src/components/pill/mastercard.d.ts", "lib/components/pill/masterc
 copyFileSync("src/components/sidebar/portaled-sidebar.d.ts", "lib/components/sidebar/portaled-sidebar.d.ts")
 copyFileSync("src/components/tabs/tab.d.ts", "lib/components/tabs/tab.d.ts")
 copyFileSync("src/components/tabs/tabs.d.ts", "lib/components/tabs/tabs.d.ts")
+copyFileSync("src/components/toggle/toggle.d.ts", "lib/components/toggle/toggle.d.ts")
 
 copyFileSync("src/components/collapsible/index.d.ts", "lib/components/collapsible/index.d.ts")
 copyFileSync("src/components/modal/index.d.ts", "lib/components/modal/index.d.ts")

--- a/copy-assets.js
+++ b/copy-assets.js
@@ -37,6 +37,8 @@ copyFileSync("src/components/pill/index.d.ts", "lib/components/pill/index.d.ts")
 copyFileSync("src/components/pill/alertMastercard.d.ts", "lib/components/pill/alertMastercard.d.ts")
 copyFileSync("src/components/pill/mastercard.d.ts", "lib/components/pill/mastercard.d.ts")
 copyFileSync("src/components/sidebar/portaled-sidebar.d.ts", "lib/components/sidebar/portaled-sidebar.d.ts")
+copyFileSync("src/components/tabs/tab.d.ts", "lib/components/tabs/tab.d.ts")
+copyFileSync("src/components/tabs/tabs.d.ts", "lib/components/tabs/tabs.d.ts")
 
 copyFileSync("src/components/collapsible/index.d.ts", "lib/components/collapsible/index.d.ts")
 copyFileSync("src/components/modal/index.d.ts", "lib/components/modal/index.d.ts")

--- a/src/components/input/use-input-value.d.ts
+++ b/src/components/input/use-input-value.d.ts
@@ -1,0 +1,24 @@
+import { ChangeEvent } from "react"
+
+export interface UseInputValueProps {
+  maxChars?: number
+  onChange?: (e: ChangeEvent) => void
+  value?: string
+}
+
+declare const useInputValue: (props: UseInputValueProps) =>
+  [
+    string,
+    (e: ChangeEvent) => void,
+    string,
+    boolean,
+    {
+      setIsDirty: (state: boolean) => void,
+      setValue: (state: string) => void,
+      resetValue: () => void
+    }
+  ]
+
+export { useInputValue }
+
+export default useInputValue

--- a/src/components/input/use-touched-state.d.ts
+++ b/src/components/input/use-touched-state.d.ts
@@ -1,0 +1,17 @@
+import { FocusEvent } from "react"
+
+export interface UseTouchedStateProps {
+  onBlur?: (e: FocusEvent) => void
+  defaultState?: boolean
+}
+
+declare const useTouchedState: (props: UseTouchedStateProps) =>
+  [
+    boolean,
+    (e: FocusEvent) => void,
+    (state: boolean) => void
+  ]
+
+export { useTouchedState }
+
+export default useTouchedState

--- a/src/components/sidebar/portaled-sidebar.d.ts
+++ b/src/components/sidebar/portaled-sidebar.d.ts
@@ -1,0 +1,19 @@
+import { ExoticComponent, FC, ReactNode } from "react"
+
+export interface PortalSidebarProps {
+  children: ReactNode
+  className?: string
+  closeOnEsc?: boolean
+  closeOnOverlayClick?: boolean
+  "data-testid"?: string
+  onClose?: () => {}
+  right?: boolean
+  Wrapper: ExoticComponent<{ children?: ReactNode }> | undefined
+  [s: string]: any
+}
+
+declare const PortalSidebar: FC<PortalSidebarProps>
+
+export { PortalSidebar }
+
+export default PortalSidebar

--- a/src/components/tabs/tab.d.ts
+++ b/src/components/tabs/tab.d.ts
@@ -1,0 +1,21 @@
+import { ChangeEvent, FC, ReactNode } from "react"
+
+export interface TabProps {
+  active?: boolean
+  disabled?: boolean
+  children?: ReactNode
+  "data-testid"?: string
+  index?: number
+  label: JSX.Element | string
+  maxWidth?: number | string
+  minWidth?: number | string
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  small?: boolean
+  [s: string]: any
+}
+
+declare const Tab: FC<TabProps>
+
+export { Tab }
+
+export default Tab

--- a/src/components/tabs/tabs.d.ts
+++ b/src/components/tabs/tabs.d.ts
@@ -1,0 +1,19 @@
+import { ChangeEvent, ExoticComponent, FC, ReactNode } from "react"
+
+export interface TabsProps {
+  children: ReactNode
+  className?: string
+  "data-testid"?: string
+  noDefaultBorder?: boolean
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+  selected: boolean
+  TabContent?: ExoticComponent<{ children?: ReactNode }> | undefined
+  TabsHeader?: ExoticComponent<{ children?: ReactNode }> | undefined
+  [s: string]: any
+}
+
+declare const Tabs: FC<TabsProps>
+
+export { Tabs }
+
+export default Tabs

--- a/src/components/toggle/toggle.d.ts
+++ b/src/components/toggle/toggle.d.ts
@@ -1,0 +1,20 @@
+import { FC, ReactNode } from "react"
+import { AlignSelfProps, MarginProps } from "src/mixins/types"
+
+export interface ToggleProps extends AlignSelfProps, MarginProps {
+  checked: boolean
+  className?: string
+  colored?: boolean
+  "data-testid"?: string
+  disabled?: boolean
+  Label: ReactNode
+  labelLeft?: string
+  labelRight?: string
+  [s: string]: any
+}
+
+declare const Toggle: FC<ToggleProps>
+
+export { Toggle }
+
+export default Toggle


### PR DESCRIPTION
This PR implements some of the missing TS declaration files of `@netdata/netdata-ui` lib for components and custom hooks that are part of the update needed for issue [Product #2776](https://github.com/netdata/product/issues/2776).
The logic behind this update was to eliminate the errors in `cloud-frontend` on the files that are being updated, so it will be easier to configure and run ESlint on GitHub checks if needed.

#### Solution
* Add TS declaration files for:
  * useInputValue hook
  * useTouchedState hook
  * PortalSidebar component
  * Tab component
  * Tabs component
  * Toggle component
* Fix JSX missing import of TS declaration files 