### PR TITLE
Control table sticky top

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/table/components/column-head/column-head.js
+++ b/src/components/table/components/column-head/column-head.js
@@ -12,11 +12,11 @@ const StyledColumnHead = styled(Flex)`
 `
 const StyledTh = styled.th`
   position: ${({ hasStickyHeader }) => hasStickyHeader && "relative"};
-  ${({ background = "mainBackground", hasStickyHeader }) =>
+  ${({ background = "mainBackground", hasStickyHeader, stickyTop = 0 }) =>
     hasStickyHeader &&
     css`
       position: sticky;
-      top: 0;
+      top: ${stickyTop};
       background: ${getColor(background)};
     `};
 `
@@ -31,10 +31,11 @@ export const ColumnHead = ({ column, sortableBy, customProps }) => {
   const sortProps = useMemo(() => (isColumnSortable ? getSortByToggleProps() : {}), [
     isColumnSortable,
   ])
-  const { hasStickyHeader } = customProps
+  const { hasStickyHeader, stickyTop } = customProps
   return layoutType === "table" ? (
     <StyledTh
       hasStickyHeader={hasStickyHeader}
+      stickyTop={stickyTop}
       {...sortProps}
       {...getHeaderProps()}
       onMouseEnter={() => setHover(true)}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -149,6 +149,7 @@ export function Table({
         className={className}
         callbackRef={callbackRef}
         hasStickyHeader={customProps.hasStickyHeader}
+        stickyTop={customProps.stickyTop}
       >
         <TableHead headerGroups={headerGroups} sortableBy={sortableBy} customProps={customProps} />
         <TableBody layoutType={layoutType} {...getTableBodyProps()}>

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -1,36 +1,41 @@
-import React, { Fragment, useEffect } from "react"
-import { StyledTabsWrapper, StyledTabs } from "./styled"
-import { useSetActive, useBuildTabs } from "./tabs-hooks"
+import React, { forwardRef, Fragment, useEffect } from "react"
+import { StyledTabs, StyledTabsWrapper } from "./styled"
+import { useBuildTabs, useSetActive } from "./tabs-hooks"
 
-export const Tabs = ({
-  className,
-  onChange,
-  selected,
-  children,
-  TabsHeader = Fragment,
-  TabContent = Fragment,
-  noDefaultBorder,
-}) => {
-  const [activeIndex, setActiveIndex] = useSetActive(selected, onChange)
+export const Tabs = forwardRef(
+  (
+    {
+      className,
+      onChange,
+      selected,
+      children,
+      TabsHeader = Fragment,
+      TabContent = Fragment,
+      noDefaultBorder,
+    },
+    ref
+  ) => {
+    const [activeIndex, setActiveIndex] = useSetActive(selected, onChange)
 
-  const [nav, content, firstActiveIndex, activeIsDisabled] = useBuildTabs(
-    children,
-    activeIndex,
-    setActiveIndex
-  )
+    const [nav, content, firstActiveIndex, activeIsDisabled] = useBuildTabs(
+      children,
+      activeIndex,
+      setActiveIndex
+    )
 
-  useEffect(() => {
-    if (activeIsDisabled && activeIndex !== firstActiveIndex) setActiveIndex(firstActiveIndex)
-  }, [activeIndex, firstActiveIndex, activeIsDisabled, setActiveIndex])
+    useEffect(() => {
+      if (activeIsDisabled && activeIndex !== firstActiveIndex) setActiveIndex(firstActiveIndex)
+    }, [activeIndex, firstActiveIndex, activeIsDisabled, setActiveIndex])
 
-  return (
-    <StyledTabsWrapper className={className}>
-      <TabsHeader>
-        <StyledTabs className="tabs" noDefaultBorder={noDefaultBorder}>
-          {nav}
-        </StyledTabs>
-      </TabsHeader>
-      <TabContent>{content}</TabContent>
-    </StyledTabsWrapper>
-  )
-}
+    return (
+      <StyledTabsWrapper className={className}>
+        <TabsHeader ref={ref}>
+          <StyledTabs className="tabs" noDefaultBorder={noDefaultBorder}>
+            {nav}
+          </StyledTabs>
+        </TabsHeader>
+        <TabContent>{content}</TabContent>
+      </StyledTabsWrapper>
+    )
+  }
+)


### PR DESCRIPTION
- pass stickyTop prop to Table, to allow precise top positioning (needed when separate sticky header is applied above the table)
- forwardRef for Tabs, to allow measuring its height