### PR TITLE
sticky th z-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/table/components/column-head/column-head.js
+++ b/src/components/table/components/column-head/column-head.js
@@ -18,6 +18,7 @@ const StyledTh = styled.th`
       position: sticky;
       top: ${stickyTop};
       background: ${getColor(background)};
+      z-index: 1;
     `};
 `
 


### PR DESCRIPTION
add z-index to sticky th (needed when table cells like icons are using transform: rotate)