### PR TITLE
fixing inputs and tab line colors

### DIFF
--- a/src/components/input/styled.js
+++ b/src/components/input/styled.js
@@ -25,12 +25,13 @@ export const StyledInput = styled.input.attrs({ round: true })`
   ${round}
   height: 100%;
   width: 100%;
+  font-weight: normal;
   flex-grow: 0;
   ${({ iconLeft }) => iconLeft && "padding-left: 0"};
   ${({ iconRight }) => iconRight && "padding-right: 0"};
   font-size: 14px;
   line-height: 18px;
-  color: ${({ disabled }) => (disabled ? getColor("placeholder") : getColor("border"))};
+  color: ${({ disabled }) => (disabled ? getColor("placeholder") : getColor("textDescription"))};
   background: ${({ disabled }) =>
     disabled ? getColor("mainBackgroundDisabled") : getColor("mainBackground")};
 
@@ -39,6 +40,7 @@ export const StyledInput = styled.input.attrs({ round: true })`
     line-height: 18px;
     color: ${getColor("placeholder")};
     opacity: 1;
+    font-weight: normal;
   }
   ${disabledCursorSupport};
 `

--- a/src/components/input/use-input-styles.js
+++ b/src/components/input/use-input-styles.js
@@ -1,4 +1,3 @@
-import { normalize } from "path"
 import { useMemo, useCallback } from "react"
 
 const makeColor = ({

--- a/src/components/input/use-input-styles.js
+++ b/src/components/input/use-input-styles.js
@@ -1,3 +1,4 @@
+import { normalize } from "path"
 import { useMemo, useCallback } from "react"
 
 const makeColor = ({

--- a/src/components/tabs/styled.js
+++ b/src/components/tabs/styled.js
@@ -15,7 +15,7 @@ export const StyledTabs = styled.nav`
 
   border-bottom: 1px solid
     ${({ noDefaultBorder }) =>
-      noDefaultBorder ? getColor(["transparent", "full"]) : getColor("border")};
+      noDefaultBorder ? getColor(["transparent", "full"]) : getColor("borderSecondary")};
   box-sizing: border-box;
 
   padding: 0 2px;

--- a/src/theme/dark/colors.js
+++ b/src/theme/dark/colors.js
@@ -50,8 +50,8 @@ const appColors = {
   nodesViewMiniCharts: rawColors.neutral.limedSpruce,
   //Input colors
   inputBorder: rawColors.neutral.bluebayoux,
-  inputBorderHover: rawColors.neutral.white,
-  inputBorderFocus: rawColors.neutral.white,
+  inputBorderHover: rawColors.neutral.bluebayoux,
+  inputBorderFocus: rawColors.neutral.limedSpruce,
   // Badges
   nodeBadgeBackground: rawColors.neutral.limedSpruce,
   nodeBadgeBorder: rawColors.neutral.bluebayoux,


### PR DESCRIPTION
Tab line
<img width="1235" alt="Screenshot 2022-06-02 at 5 42 17 PM" src="https://user-images.githubusercontent.com/7236896/171655966-00e20d22-5a9b-474a-93be-f716c7ada170.png">
It is also imported in the drawer, already checked, not so necessary to be so highlighted in that case.


<img width="440" alt="Screenshot 2022-06-02 at 5 41 56 PM" src="https://user-images.githubusercontent.com/7236896/171656117-d80d94c9-f9a1-4b55-955f-e538b37fe061.png">
<img width="417" alt="Screenshot 2022-06-02 at 5 42 06 PM" src="https://user-images.githubusercontent.com/7236896/171656124-bc1416f5-5644-4930-a005-a9c5ecb0f34f.png">
Checked the inputs also in dark mode, they seem okay.
