### PR TITLE
update warning and error colors

### DIFF
--- a/src/theme/dark/colors.js
+++ b/src/theme/dark/colors.js
@@ -22,17 +22,17 @@ const appColors = {
   success: rawColors.green.netdata,
   successLite: rawColors.green.deyork,
   successBackground: rawColors.green.deyork,
-  successText: rawColors.neutral.limedSpruce,
+  successText: rawColors.green.netdata,
 
   warning: rawColors.yellow.seaBuckthorn,
   warningLite: rawColors.yellow.sunglow,
   warningBackground: rawColors.yellow.salomie,
-  warningText: rawColors.neutral.limedSpruce,
+  warningText: rawColors.yellow.seaBuckthorn,
 
   error: rawColors.red.pomegranate,
   errorLite: rawColors.red.apricot,
   errorBackground: rawColors.red.wewak,
-  errorText: rawColors.neutral.limedSpruce,
+  errorText: rawColors.red.pomegranate,
 
   attention: rawColors.purple.mauve,
   attentionSecondary: rawColors.purple.daisy,


### PR DESCRIPTION
Before:
![Screenshot 2022-07-28 at 12 43 40](https://user-images.githubusercontent.com/96468003/181475987-cee0b211-4023-450e-8585-07999bb0c567.png)

After:
![Screenshot 2022-07-28 at 12 43 47](https://user-images.githubusercontent.com/96468003/181476025-2a94002c-605b-4432-8d28-84ba596fada8.png)


