### PR TITLE
remove height overrides

### DIFF
--- a/src/components/pill/alertMastercard.js
+++ b/src/components/pill/alertMastercard.js
@@ -27,7 +27,6 @@ const AlertMasterCard = forwardRef(
       icon: "alarm_bell",
       zIndex: 1,
       ...commonProps,
-      height: "18px",
     }
     const pillProps = {
       normal,
@@ -49,7 +48,7 @@ const AlertMasterCard = forwardRef(
       padding: [1, 2, 1, 4],
       ...pillProps,
       ...pillLeft,
-      height: "18px",
+      round: "0 12px 12px 0",
     }
     const pillRightProps = {
       background: pillRightBackground,
@@ -57,7 +56,6 @@ const AlertMasterCard = forwardRef(
       padding: [1, 2, 1, 4],
       ...pillProps,
       ...pillRight,
-      height: "18px",
     }
 
     return (

--- a/src/components/pill/mastercard.js
+++ b/src/components/pill/mastercard.js
@@ -37,7 +37,6 @@ const MasterCard = forwardRef(
       width: { min: minWidths[rest.size] || minWidths.default },
       ...pillProps,
       ...pillLeft,
-      height: "18px",
     }
     const pillRightProps = {
       background: pillRightBackground,
@@ -45,7 +44,6 @@ const MasterCard = forwardRef(
       padding: [1, 2],
       ...pillProps,
       ...pillRight,
-      height: "18px",
     }
 
     return (

--- a/src/components/pill/mixins/height.js
+++ b/src/components/pill/mixins/height.js
@@ -1,6 +1,6 @@
 const pillHeights = {
-  default: '20px',
-  large: '24px',
+  default: "18px",
+  large: "22px",
 }
 
 const getPillHeight = (height, size, tiny) => {

--- a/src/components/pill/mixins/height.test.js
+++ b/src/components/pill/mixins/height.test.js
@@ -11,10 +11,10 @@ describe("getPillHeight mixin", () => {
   })
 
   test("should return height for large sized pill", () => {
-    expect(getPillHeight(undefined, "large", undefined)).toEqual("24px")
+    expect(getPillHeight(undefined, "large", undefined)).toEqual("22px")
   })
 
   test("should return default height", () => {
-    expect(getPillHeight(undefined, undefined, undefined)).toEqual("20px")
+    expect(getPillHeight(undefined, undefined, undefined)).toEqual("18px")
   })
 })


### PR DESCRIPTION
Remove height overrides, causing them to ignore `size` prop in alert mastercard and update them in height mixins. Override also the radius of left pill in alert mastercard

Before
<img width="127" alt="Screenshot 2022-09-13 at 12 01 10" src="https://user-images.githubusercontent.com/96468003/189859463-39675e49-0fe7-4934-b37b-b757f7f5ecea.png">

After
<img width="189" alt="Screenshot 2022-09-13 at 12 01 27" src="https://user-images.githubusercontent.com/96468003/189859512-ebb133a3-e7cb-4f50-a962-f3950a2cbe50.png">
