### PR TITLE
chore: update AlertMasterCard testId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/pill/alertMastercard.js
+++ b/src/components/pill/alertMastercard.js
@@ -59,12 +59,7 @@ const AlertMasterCard = forwardRef(
     }
 
     return (
-      <MasterCardContainer
-        data-testid={`${testId}-container`}
-        onClick={onClick}
-        ref={ref}
-        {...commonProps}
-      >
+      <MasterCardContainer data-testid={testId} onClick={onClick} ref={ref} {...commonProps}>
         <MasterCardPill data-testid={`${testId}-icon-pill`} {...iconProps} />
         <>
           <MasterCardPill data-testid={`${testId}-left-pill`} {...pillLeftProps} />

--- a/src/components/pill/alertMastercard.js
+++ b/src/components/pill/alertMastercard.js
@@ -7,7 +7,6 @@ import { MasterCardContainer } from "./styled"
 const AlertMasterCard = forwardRef(
   (
     {
-      children,
       "data-testid": testId = "alert-mastercard",
       height,
       normal,

--- a/src/components/pill/alertMastercard.test.js
+++ b/src/components/pill/alertMastercard.test.js
@@ -6,7 +6,7 @@ describe("MasterCardPill component", () => {
   test("should render default component", () => {
     renderWithProviders(<AlertMasterCard />)
 
-    expect(screen.queryByTestId("alert-mastercard-container")).toBeInTheDocument()
+    expect(screen.queryByTestId("alert-mastercard")).toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-icon-pill")).toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-left-pill")).toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-right-pill")).toBeInTheDocument()
@@ -15,7 +15,7 @@ describe("MasterCardPill component", () => {
   test("should render component with custom test id", () => {
     renderWithProviders(<AlertMasterCard data-testid="custom-alert-mastercard" />)
 
-    expect(screen.queryByTestId("alert-mastercard-container")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("alert-mastercard")).not.toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-icon-pill")).not.toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard")).not.toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-left-pill")).not.toBeInTheDocument()

--- a/src/components/pill/alertMastercard.test.js
+++ b/src/components/pill/alertMastercard.test.js
@@ -17,10 +17,9 @@ describe("MasterCardPill component", () => {
 
     expect(screen.queryByTestId("alert-mastercard")).not.toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-icon-pill")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("alert-mastercard")).not.toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-left-pill")).not.toBeInTheDocument()
     expect(screen.queryByTestId("alert-mastercard-right-pill")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("custom-alert-mastercard-container")).toBeInTheDocument()
+    expect(screen.queryByTestId("custom-alert-mastercard")).toBeInTheDocument()
     expect(screen.queryByTestId("custom-alert-mastercard-icon-pill")).toBeInTheDocument()
     expect(screen.queryByTestId("custom-alert-mastercard-left-pill")).toBeInTheDocument()
     expect(screen.queryByTestId("custom-alert-mastercard-right-pill")).toBeInTheDocument()


### PR DESCRIPTION
This PR replaces the `data-testid` attribute value of the container with the default `testId` provided to `AlertMasterCard` component, so that the users can run their tests by checking for the `testId` they have provided to the component.