### PR TITLE
chore(confirmation dialog): update strong tag styles inside body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.3.10",
+  "version": "2.3.11",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/confirmation-dialog/confirmation-dialog.d.ts
+++ b/src/components/confirmation-dialog/confirmation-dialog.d.ts
@@ -10,9 +10,10 @@ export interface ConfirmationDialogProps {
   declineLabel?: string
   declineWidth?: string
   handleConfirm: OnClickType
-  handleDecline: OnClickType
+  handleDecline?: OnClickType
   hideIcon?: boolean
   iconName?: string
+  isConfirmDisabled?: boolean
   isConfirmPositive?: boolean
   message: JSX.Element | string
   title: string

--- a/src/components/confirmation-dialog/confirmation-dialog.js
+++ b/src/components/confirmation-dialog/confirmation-dialog.js
@@ -18,6 +18,7 @@ const ConfirmationDialog = ({
   handleDecline,
   hideIcon,
   iconName = "warning_triangle_hollow",
+  isConfirmDisabled,
   isConfirmPositive,
   message,
   title,
@@ -30,24 +31,29 @@ const ConfirmationDialog = ({
             {!hideIcon && <TitleIcon data-testid={`${dataTestId}-headerIcon`} name={iconName} />}
             <Title data-testid={`${dataTestId}-headerText`}>{title}</Title>
           </Flex>
-          <CloseButton data-testid={`${dataTestId}-headerClose`} onClose={handleDecline} />
+          {handleDecline && (
+            <CloseButton data-testid={`${dataTestId}-headerClose`} onClose={handleDecline} />
+          )}
         </Header>
         <Body data-testid={`${dataTestId}-body`}>
           <BodyMessage data-testid={`${dataTestId}-bodyMessage`}>{message}</BodyMessage>
         </Body>
         <Actions data-testid={`${dataTestId}-actions`}>
-          <Button
-            data-ga={`${dataGA}-::click-cancel::global-view`}
-            data-testid={`${dataTestId}-cancelAction`}
-            flavour="hollow"
-            label={declineLabel}
-            onClick={handleDecline}
-            width={declineWidth}
-          />
+          {handleDecline && (
+            <Button
+              data-ga={`${dataGA}-::click-cancel::global-view`}
+              data-testid={`${dataTestId}-cancelAction`}
+              flavour="hollow"
+              label={declineLabel}
+              onClick={handleDecline}
+              width={declineWidth}
+            />
+          )}
           <Button
             data-ga={`${dataGA}-::click-confirm::global-view`}
             data-testid={`${dataTestId}-confirmAction`}
             danger={!isConfirmPositive && true}
+            disabled={isConfirmDisabled}
             label={confirmLabel}
             onClick={handleConfirm}
             width={confirmWidth}

--- a/src/components/confirmation-dialog/styled.js
+++ b/src/components/confirmation-dialog/styled.js
@@ -41,6 +41,10 @@ export const Body = styled(ModalBody).attrs({
   padding: [0],
 })`
   display: block;
+
+  strong {
+    font-weight: bold;
+  }
 `
 
 export const Dialog = styled(Modal).attrs({


### PR DESCRIPTION
This PR updates the styles of **Confirmation Dialog** body in order to highlight the texts wrapped inside `strong` HTML tag.
The styling seems to have been broken in the latest versions of `cloud-frontend` repo.

Also, it updates **Confirmation Dialog** functionality by making `handleDecline` prop optional and adding an extra prop that gives the user the option to make confirmation action disabled.