### PR TITLE
fix: disable box-shadow by default from drop components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.3.17",
+  "version": "2.3.18",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/drops/drop/container.js
+++ b/src/components/drops/drop/container.js
@@ -24,9 +24,9 @@ const Container = styled(Flex).attrs(({ zIndex = 60 }) => ({ zIndex }))`
   z-index: 36;
 
   ${({ animation }) => animation && styledAnimation}
+  ${({ hideShadow }) => !hideShadow && "box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);"}
 
   backface-visibility: hidden;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   perspective: 1000;
   transform: translate3d(0, 0, 0);
   will-change: left, top, transform;

--- a/src/components/drops/drop/index.d.ts
+++ b/src/components/drops/drop/index.d.ts
@@ -2,14 +2,15 @@ import { FlexProps } from "../../templates/flex"
 import { AlignProps, StretchProps } from "../mixins"
 
 export interface DropProps extends FlexProps, AlignProps, StretchProps {
-  target: object
-  onClickOutside?: Function
-  onEsc?: Function
-  children: any
-  canHideTarget?: boolean
-  [key: string]: any
   backdrop?: boolean
   backdropProps?: any
+  canHideTarget?: boolean
+  children: any
+  hideShadow: boolean
+  onClickOutside?: Function
+  onEsc?: Function
+  target: object
+  [key: string]: any
 }
 
 declare const Drop: React.FC<DropProps & JSX.IntrinsicElements["div"]>

--- a/src/components/drops/menu/index.js
+++ b/src/components/drops/menu/index.js
@@ -91,10 +91,11 @@ const Menu = forwardRef(
         )}
         {isOpen && ref.current && (
           <Drop
-            target={ref.current}
+            animation={animation}
             onEsc={close}
             onClickOutside={onClickOutside}
-            animation={animation}
+            hideShadow
+            target={ref.current}
             {...dropProps}
           >
             {renderDropdown({ value, onItemClick, items, itemProps, renderItem })}

--- a/src/components/drops/popover/index.js
+++ b/src/components/drops/popover/index.js
@@ -61,13 +61,14 @@ const Popover = forwardRef(
         {isOpen && ref.current && (
           <Drop
             id={id}
+            hideShadow
             {...dropProps}
             align={dropProps?.align || dropAlignMap[align]}
-            target={ref.current}
+            animation={animation}
+            onEsc={close}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            onEsc={close}
-            animation={animation}
+            target={ref.current}
             zIndex={zIndex}
           >
             {plain ? (

--- a/src/components/drops/tooltip/index.js
+++ b/src/components/drops/tooltip/index.js
@@ -68,18 +68,19 @@ const Tooltip = forwardRef(
         {targetElement}
         {isOpen && ref.current && !disabled && (
           <Drop
+            align={dropProps?.align || dropAlignMap[align]}
+            hideShadow
+            id={id}
+            onClickOutside={close}
             onMouseLeave={() => {
               setHasPopUpHovered(false)
               close()
             }}
             onMouseEnter={() => setHasPopUpHovered(true)}
-            onClickOutside={close}
             target={ref.current}
-            id={id}
             {...dropProps}
-            align={dropProps?.align || dropAlignMap[align]}
-            onEsc={close}
             animation={animation}
+            onEsc={close}
             zIndex={zIndex}
           >
             {plain ? (


### PR DESCRIPTION
Disable `box-shadow` default style setting of `Drop` component for the rest components of the group