### PR TITLE
fix table column TH align

### DIFF
--- a/src/components/table/components/table-head/styled.js
+++ b/src/components/table/components/table-head/styled.js
@@ -5,5 +5,6 @@ export const StyledThead = styled.thead`
     border-spacing: 0;
     border-bottom: 1px solid #aeb3b7;
     padding-bottom: 5px;
+    text-align: left;
   }
 `


### PR DESCRIPTION
add missing text-align, which was missing since we deleted global .css files in cloud-fe