### PR TITLE
remove redundant height from labels and add margin bottom

### DIFF
--- a/src/components/input/styled.js
+++ b/src/components/input/styled.js
@@ -50,17 +50,16 @@ export const StyledLabel = styled.label`
   display: block;
   ${disabledCursorSupport};
 `
-export const LabelRow = styled.div`
-  width: 100%;
-  flex-shrink: 0;
-  flex-grow: 0;
+export const LabelRow = styled(Flex).attrs({
+  alignItems: "center",
+  color: "text",
+  flex: false,
+  width: "100%",
+})`
   font-style: normal;
   font-weight: bold;
   font-size: 14px;
   line-height: 18px;
-  color: ${getColor("text")};
-  display: flex;
-  align-items: center;
   margin-bottom: 4px;
 `
 

--- a/src/components/input/styled.js
+++ b/src/components/input/styled.js
@@ -52,7 +52,6 @@ export const StyledLabel = styled.label`
 `
 export const LabelRow = styled.div`
   width: 100%;
-  height: 40px;
   flex-shrink: 0;
   flex-grow: 0;
   font-style: normal;
@@ -62,6 +61,7 @@ export const LabelRow = styled.div`
   color: ${getColor("text")};
   display: flex;
   align-items: center;
+  margin-bottom: 4px;
 `
 
 export const InputContainer = styled(Flex)`


### PR DESCRIPTION
Before
![Screenshot 2022-11-29 at 11 12 26](https://user-images.githubusercontent.com/96468003/204488399-f6172344-e523-459d-b7ef-5c4431040b19.png)
After
![Screenshot 2022-11-29 at 11 12 58](https://user-images.githubusercontent.com/96468003/204488431-cc7ac51b-32f6-43d3-9b6c-a909f7913897.png)
