### PR TITLE
chore(netdata table): update table column menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -15,36 +15,36 @@ import {
 export const Checkbox = forwardRef(
   (
     {
+      alignSelf,
       checked,
+      className,
       "data-testid": testId,
       disabled,
-      className,
-      labelPosition,
-      label,
-      indeterminate,
-      margin,
-      alignSelf,
       iconProps,
+      indeterminate,
       Label,
+      label,
+      labelPosition,
+      margin,
       ...props
     },
     ref
   ) => {
     const { styles } = useCheckBoxStyles({ disabled })
     const { getInputProps, getCheckBoxProps } = useCheckbox({
-      disabled,
       checked,
+      disabled,
       indeterminate,
       ...props,
     })
 
     return (
       <StyledLabel
+        alignSelf={alignSelf}
+        className={className}
         data-testid={testId}
         disabled={disabled}
-        className={className}
         margin={margin}
-        alignSelf={alignSelf}
       >
         {label && labelPosition === "left" && (
           <LabelText as={Label} disabled={disabled} left>
@@ -59,8 +59,8 @@ export const Checkbox = forwardRef(
             {...getCheckBoxProps()}
           >
             <StyledIcon
-              name={indeterminate ? "checkmark_partial_s" : "checkmark_s"}
               disabled={disabled}
+              name={indeterminate ? "checkmark_partial_s" : "checkmark_s"}
               {...iconProps}
             />
           </StyledCheckbox>
@@ -76,6 +76,6 @@ export const Checkbox = forwardRef(
 )
 
 Checkbox.defaultProps = {
-  labelPosition: "right",
   Label: Text,
+  labelPosition: "right",
 }

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -3,68 +3,77 @@ import { Text } from "src/components/typography"
 import useCheckBoxStyles from "./use-styles-checkbox"
 import useCheckbox from "./use-checkbox"
 
-import { CheckboxContainer, HiddenCheckboxInput, LabelText, StyledCheckbox, StyledIcon, StyledLabel } from "./styled"
+import {
+  CheckboxContainer,
+  HiddenCheckboxInput,
+  LabelText,
+  StyledCheckbox,
+  StyledIcon,
+  StyledLabel,
+} from "./styled"
 
-export const Checkbox = forwardRef((
-  {
-    checked,
-    "data-testid": testId,
-    disabled,
-    className,
-    labelPosition,
-    label,
-    indeterminate,
-    margin,
-    alignSelf,
-    iconProps,
-    Label,
-    ...props
-  },
+export const Checkbox = forwardRef(
+  (
+    {
+      checked,
+      "data-testid": testId,
+      disabled,
+      className,
+      labelPosition,
+      label,
+      indeterminate,
+      margin,
+      alignSelf,
+      iconProps,
+      Label,
+      ...props
+    },
     ref
-) => {
-  const { styles } = useCheckBoxStyles({ disabled })
-  const { getInputProps, getCheckBoxProps } = useCheckbox({
-    disabled,
-    checked,
-    indeterminate,
-    ...props,
-  })
+  ) => {
+    const { styles } = useCheckBoxStyles({ disabled })
+    const { getInputProps, getCheckBoxProps } = useCheckbox({
+      disabled,
+      checked,
+      indeterminate,
+      ...props,
+    })
 
-  return (
-    <StyledLabel
-      data-testid={testId}
-      disabled={disabled}
-      className={className}
-      margin={margin}
-      alignSelf={alignSelf}
-    >
-      {label && labelPosition === "left" && (
-        <LabelText as={Label} left>
-          {label}
-        </LabelText>
-      )}
-      <CheckboxContainer>
-        <HiddenCheckboxInput data-testid="checkbox-input" {...getInputProps(ref, props)} />
-        <StyledCheckbox
-          data-testid="styled-checkbox"
-          {...styles.styledCheckbox}
-          {...getCheckBoxProps()}
-        >
-          <StyledIcon
-            name={indeterminate ? "checkmark_partial_s" : "checkmark_s"}
-            disabled={disabled}
-            {...iconProps}
-          />
-        </StyledCheckbox>
-      </CheckboxContainer>
-      {label && labelPosition === "right" && (
-        <LabelText as={Label} right>
-          {label}
-        </LabelText>
-      )}
-    </StyledLabel>
-  )
-})
+    return (
+      <StyledLabel
+        data-testid={testId}
+        disabled={disabled}
+        className={className}
+        margin={margin}
+        alignSelf={alignSelf}
+      >
+        {label && labelPosition === "left" && (
+          <LabelText as={Label} disabled={disabled} left>
+            {label}
+          </LabelText>
+        )}
+        <CheckboxContainer>
+          <HiddenCheckboxInput data-testid="checkbox-input" {...getInputProps(ref, props)} />
+          <StyledCheckbox
+            data-testid="styled-checkbox"
+            {...styles.styledCheckbox}
+            {...getCheckBoxProps()}
+          >
+            <StyledIcon
+              name={indeterminate ? "checkmark_partial_s" : "checkmark_s"}
+              disabled={disabled}
+              {...iconProps}
+            />
+          </StyledCheckbox>
+        </CheckboxContainer>
+        {label && labelPosition === "right" && (
+          <LabelText as={Label} disabled={disabled} right>
+            {label}
+          </LabelText>
+        )}
+      </StyledLabel>
+    )
+  }
+)
 
 Checkbox.defaultProps = {
   labelPosition: "right",

--- a/src/components/checkbox/styled.js
+++ b/src/components/checkbox/styled.js
@@ -1,19 +1,23 @@
 import styled from "styled-components"
 import { Icon } from "src/components/icon"
+import Box from "src/components/templates/box"
 import { getSizeUnit, getValidatedControlColor } from "src/theme/utils"
 import margin from "src/mixins/margin"
 import alignSelf from "src/mixins/alignSelf"
 
 import Flex from "src/components/templates/flex"
 
-export const CheckboxContainer = styled.div`
-  display: block;
+export const CheckboxContainer = styled(Box).attrs({
+  height: "16px",
+  width: "16px",
+})`
   box-sizing: border-box;
-  width: 20px;
-  height: 20px;
 `
 
-export const StyledIcon = styled(Icon)`
+export const StyledIcon = styled(Icon).attrs({
+  height: "inherit",
+  width: "inherit",
+})`
   flex-grow: 0;
   flex-shrink: 0;
   fill: ${getValidatedControlColor("primary", "accent")};
@@ -57,5 +61,6 @@ export const StyledLabel = styled.label`
 
 export const LabelText = styled.span`
   ${({ right, ...props }) =>
-    right ? `margin-left: ${getSizeUnit(props)}px;` : `margin-right: ${getSizeUnit(props)}px;`}
+    right ? `margin-left: ${getSizeUnit(props)}px;` : `margin-right: ${getSizeUnit(props)}px;`};
+  ${({ disabled }) => disabled && "opacity: 0.4;"};
 `

--- a/src/components/checkbox/use-styles-checkbox.js
+++ b/src/components/checkbox/use-styles-checkbox.js
@@ -2,25 +2,22 @@ import { useMemo } from "react"
 
 const makeColor = ({
   defaultColor = "inputBorder",
-  success = "success",
-  error = "error",
   disabled = "inputBorder",
+  error = "error",
+  success = "success",
 }) => ({
-  success: success,
-  error: error,
-  disabled: disabled,
   default: defaultColor,
+  disabled: disabled,
+  error: error,
+  success: success,
 })
 const useCheckboxStyles = ({ disabled, success, error, focused }) => {
   const status = success ? "success" : error ? "error" : disabled ? "disabled" : "default"
 
   const styledCheckbox = useMemo(
     () => ({
-      width: "inherit",
-      height: "inherit",
-      background: disabled ? "mainBackgroundDisabled" : "mainBackground",
-      justifyContent: "center",
       alignItems: "center",
+      background: disabled ? "mainBackgroundDisabled" : "mainBackground",
       border: {
         size: "1px",
         type: "solid",
@@ -29,13 +26,16 @@ const useCheckboxStyles = ({ disabled, success, error, focused }) => {
           : makeColor({})[status],
         side: "all",
       },
+      height: "inherit",
+      justifyContent: "center",
       round: true,
+      width: "inherit",
       _focus: {
         border: {
-          size: "1px",
-          type: "solid",
           color: makeColor({ defaultColor: "controlFocused" })[status],
           side: "all",
+          size: "1px",
+          type: "solid",
         },
         boxShadow: {
           color: makeColor({ defaultColor: "controlFocused" })[status],

--- a/src/components/checkbox/use-styles-checkbox.js
+++ b/src/components/checkbox/use-styles-checkbox.js
@@ -14,10 +14,10 @@ const makeColor = ({
 const useCheckboxStyles = ({ disabled, success, error, focused }) => {
   const status = success ? "success" : error ? "error" : disabled ? "disabled" : "default"
 
-  const styledCheckbox = useMemo(() => {
-    return {
-      width: "20px",
-      height: "20px",
+  const styledCheckbox = useMemo(
+    () => ({
+      width: "inherit",
+      height: "inherit",
       background: disabled ? "mainBackgroundDisabled" : "mainBackground",
       justifyContent: "center",
       alignItems: "center",
@@ -42,8 +42,9 @@ const useCheckboxStyles = ({ disabled, success, error, focused }) => {
           size: "0 0 0 1px",
         },
       },
-    }
-  }, [status, focused])
+    }),
+    [status, focused]
+  )
 
   return { styles: { styledCheckbox } }
 }

--- a/src/components/drops/drop/index.d.ts
+++ b/src/components/drops/drop/index.d.ts
@@ -6,7 +6,7 @@ export interface DropProps extends FlexProps, AlignProps, StretchProps {
   backdropProps?: any
   canHideTarget?: boolean
   children: any
-  hideShadow: boolean
+  hideShadow?: boolean
   onClickOutside?: Function
   onEsc?: Function
   target: object

--- a/src/components/drops/mixins/index.d.ts
+++ b/src/components/drops/mixins/index.d.ts
@@ -1,5 +1,5 @@
 export interface AlignProps {
-  align:
+  align?:
     | { top: "top" }
     | { top: "top"; right: "left" }
     | { top: "top"; right: "right" }

--- a/src/components/tableV2/components/actionWithDropdown.js
+++ b/src/components/tableV2/components/actionWithDropdown.js
@@ -6,6 +6,8 @@ import ColumnsMenu from "./columnsMenu" //todo refactor this as right now is use
 const ActionWithDropdown = ({
   id,
   icon,
+  columnPinning = {},
+  enableColumnPinning,
   handleAction,
   tooltipText,
   alwaysEnabled,
@@ -21,6 +23,26 @@ const ActionWithDropdown = ({
   const actionRef = useRef()
   const disabled = typeof isDisabled === "function" ? isDisabled() : isDisabled
   const visible = typeof isVisible === "function" ? isVisible() : isVisible
+  const allColumns = table.getAllLeafColumns()
+  const allPinnedColumns = enableColumnPinning
+    ? [...(columnPinning?.left || []), ...(columnPinning?.right || [])]
+    : []
+  const { columns, pinnedColumns } = enableColumnPinning
+    ? allColumns.reduce(
+        (accumulator, column) => {
+          let key = "columns"
+          if (allPinnedColumns.includes(column.id)) {
+            key = "pinnedColumns"
+          }
+
+          return {
+            ...accumulator,
+            [key]: [...accumulator[key], column],
+          }
+        },
+        { columns: [], pinnedColumns: [] }
+      )
+    : { columns: allColumns, pinnedColumns: [] }
 
   return (
     <>
@@ -40,7 +62,8 @@ const ActionWithDropdown = ({
       <ColumnsMenu
         parentRef={actionRef}
         isOpen={isOpen}
-        columns={table.getAllLeafColumns()}
+        columns={columns}
+        pinnedColumns={pinnedColumns}
         onClose={onClose}
       />
     </>

--- a/src/components/tableV2/components/actionWithDropdown.js
+++ b/src/components/tableV2/components/actionWithDropdown.js
@@ -4,25 +4,26 @@ import BulkAction from "./bulkAction"
 import ColumnsMenu from "./columnsMenu" //todo refactor this as right now is used only for the dropdown for column visibility
 
 const ActionWithDropdown = ({
-  id,
-  icon,
+  alwaysEnabled,
   columnPinning = {},
   enableColumnPinning,
   handleAction,
-  tooltipText,
-  alwaysEnabled,
+  id,
+  icon,
   isDisabled,
+  isOpen,
   isVisible,
-  testPrefix,
+  onClose,
   selectedRows,
   table,
-  isOpen,
-  onClose,
+  testPrefix,
+  tooltipText,
   ...rest
 }) => {
   const actionRef = useRef()
   const disabled = typeof isDisabled === "function" ? isDisabled() : isDisabled
   const visible = typeof isVisible === "function" ? isVisible() : isVisible
+
   const allColumns = table.getAllLeafColumns()
   const allPinnedColumns = enableColumnPinning
     ? [...(columnPinning?.left || []), ...(columnPinning?.right || [])]
@@ -60,11 +61,11 @@ const ActionWithDropdown = ({
         {...rest}
       />
       <ColumnsMenu
-        parentRef={actionRef}
-        isOpen={isOpen}
         columns={columns}
-        pinnedColumns={pinnedColumns}
+        isOpen={isOpen}
         onClose={onClose}
+        parentRef={actionRef}
+        pinnedColumns={pinnedColumns}
       />
     </>
   )

--- a/src/components/tableV2/components/actionWithDropdown.js
+++ b/src/components/tableV2/components/actionWithDropdown.js
@@ -31,6 +31,8 @@ const ActionWithDropdown = ({
   const { columns, pinnedColumns } = enableColumnPinning
     ? allColumns.reduce(
         (accumulator, column) => {
+          if (!column.getCanHide()) return accumulator
+
           let key = "columns"
           if (allPinnedColumns.includes(column.id)) {
             key = "pinnedColumns"

--- a/src/components/tableV2/components/columnsMenu.js
+++ b/src/components/tableV2/components/columnsMenu.js
@@ -1,10 +1,10 @@
 import React from "react"
 import Drop from "src/components/drops/drop/index.js"
-import { Text, ListItem } from "src/components/typography"
-import { Checkbox } from "src/components/checkbox"
+import { Text } from "src/components/typography"
 import Flex from "src/components/templates/flex"
+import ColumnsMenuItem from "src/components/tableV2/components/columnsMenuItem"
 
-const ColumnsMenu = ({ parentRef, isOpen, columns, onClose }) => {
+const ColumnsMenu = ({ parentRef, isOpen, columns, onClose, pinnedColumns }) => {
   if (parentRef.current && isOpen)
     return (
       <Drop
@@ -16,47 +16,38 @@ const ColumnsMenu = ({ parentRef, isOpen, columns, onClose }) => {
         target={parentRef.current}
         width={50}
       >
-        <>
-          <Flex
-            padding={[2]}
-            border={{
-              size: "1px",
-              type: "solid",
-              side: "bottom",
-              color: "borderSecondary",
-            }}
-          >
-            <Text strong>Columns</Text>
-          </Flex>
+        <Flex
+          padding={[3, 3, 1]}
+          border={{
+            size: "1px",
+            type: "solid",
+            side: "bottom",
+            color: "borderSecondary",
+          }}
+        >
+          <Text color="textLite">Edit columns</Text>
+        </Flex>
 
-          {columns.map(column => {
-            {
-              return (
-                column.getCanHide() && (
-                  <Flex
-                    padding={[2]}
-                    as={ListItem}
-                    alignItems="center"
-                    justifyContent="between"
-                    key={column.id}
-                    border={{
-                      size: "1px",
-                      type: "solid",
-                      side: "bottom",
-                      color: "borderSecondary",
-                    }}
-                  >
-                    <Checkbox
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                      label={column.id}
-                    />
-                  </Flex>
-                )
-              )
-            }
-          })}
-        </>
+        <Flex column padding={[1, 3]}>
+          {pinnedColumns.length ? (
+            <Flex
+              border={{
+                size: "1px",
+                type: "solid",
+                side: "bottom",
+                color: "borderSecondary",
+              }}
+              column
+            >
+              {pinnedColumns.map(pinnedColumn => (
+                <ColumnsMenuItem column={pinnedColumn} disabled key={pinnedColumn.id} />
+              ))}
+            </Flex>
+          ) : null}
+          {columns.map(column => (
+            <ColumnsMenuItem column={column} key={column.id} />
+          ))}
+        </Flex>
       </Drop>
     )
 

--- a/src/components/tableV2/components/columnsMenu.js
+++ b/src/components/tableV2/components/columnsMenu.js
@@ -1,7 +1,7 @@
 import React from "react"
 import Drop from "src/components/drops/drop/index.js"
-import { Text } from "src/components/typography"
 import Flex from "src/components/templates/flex"
+import { Text } from "src/components/typography"
 import ColumnsMenuItem from "src/components/tableV2/components/columnsMenuItem"
 
 const ColumnsMenu = ({ parentRef, isOpen, columns, onClose, pinnedColumns }) => {
@@ -17,13 +17,13 @@ const ColumnsMenu = ({ parentRef, isOpen, columns, onClose, pinnedColumns }) => 
         width={50}
       >
         <Flex
-          padding={[3, 3, 1]}
           border={{
             size: "1px",
             type: "solid",
             side: "bottom",
             color: "borderSecondary",
           }}
+          padding={[3, 3, 1]}
         >
           <Text color="textLite">Edit columns</Text>
         </Flex>

--- a/src/components/tableV2/components/columnsMenuItem.js
+++ b/src/components/tableV2/components/columnsMenuItem.js
@@ -1,0 +1,21 @@
+import React from "react"
+import { Checkbox } from "src/components/checkbox"
+import Flex from "src/components/templates/flex"
+import { ListItem } from "src/components/typography"
+
+const ColumnsMenuItem = ({ column, disabled }) => {
+  if (!column.getCanHide()) return null
+
+  return (
+    <Flex alignItems="center" as={ListItem} justifyContent="between" padding={[1]}>
+      <Checkbox
+        checked={column.getIsVisible()}
+        disabled={disabled}
+        label={column.id}
+        onChange={column.getToggleVisibilityHandler()}
+      />
+    </Flex>
+  )
+}
+
+export default ColumnsMenuItem

--- a/src/components/tableV2/components/columnsMenuItem.js
+++ b/src/components/tableV2/components/columnsMenuItem.js
@@ -3,19 +3,15 @@ import { Checkbox } from "src/components/checkbox"
 import Flex from "src/components/templates/flex"
 import { ListItem } from "src/components/typography"
 
-const ColumnsMenuItem = ({ column, disabled }) => {
-  if (!column.getCanHide()) return null
-
-  return (
-    <Flex alignItems="center" as={ListItem} justifyContent="between" padding={[1]}>
-      <Checkbox
-        checked={column.getIsVisible()}
-        disabled={disabled}
-        label={column.id}
-        onChange={column.getToggleVisibilityHandler()}
-      />
-    </Flex>
-  )
-}
+const ColumnsMenuItem = ({ column, disabled }) => (
+  <Flex alignItems="center" as={ListItem} justifyContent="between" padding={[1]}>
+    <Checkbox
+      checked={column.getIsVisible()}
+      disabled={disabled}
+      label={column.id}
+      onChange={column.getToggleVisibilityHandler()}
+    />
+  </Flex>
+)
 
 export default ColumnsMenuItem

--- a/src/components/tableV2/features/bulkActions.js
+++ b/src/components/tableV2/features/bulkActions.js
@@ -27,6 +27,8 @@ export const supportedBulkActions = {
 //TODO THIS NEEDS TO BE REFACTORED NOW IS WORKING ONLY FOR COLUMN VISIBILITY
 const renderActionWithDropdown = ({
   actions,
+  columnPinning,
+  enableColumnPinning,
   table,
   testPrefix,
   selectedRows,
@@ -38,6 +40,8 @@ const renderActionWithDropdown = ({
     ({ id, icon, handleAction, tooltipText, alwaysEnabled, isDisabled, isVisible, ...rest }) => {
       return (
         <ActionWithDropdown
+          columnPinning={columnPinning}
+          enableColumnPinning={enableColumnPinning}
           key={id}
           isVisible={isVisible}
           alwaysEnabled={alwaysEnabled}
@@ -67,6 +71,8 @@ const makeColumnVisibilityAction = ({ handleAction, visible }) => ({
 
 const makeBulkActions = ({
   bulkActions,
+  columnPinning,
+  enableColumnPinning,
   table,
   testPrefix,
   selectedRows,
@@ -75,6 +81,8 @@ const makeBulkActions = ({
   const columnVisibility = makeColumnVisibilityAction({ ...columnVisibilityOptions })
   const actionsWithDropdown = renderActionWithDropdown({
     actions: [columnVisibility],
+    columnPinning,
+    enableColumnPinning,
     ...columnVisibilityOptions,
     testPrefix,
     table,

--- a/src/components/tableV2/features/bulkActions.js
+++ b/src/components/tableV2/features/bulkActions.js
@@ -29,9 +29,9 @@ const renderActionWithDropdown = ({
   actions,
   columnPinning,
   enableColumnPinning,
+  selectedRows,
   table,
   testPrefix,
-  selectedRows,
   isOpen,
   onClose,
 }) => {
@@ -40,20 +40,20 @@ const renderActionWithDropdown = ({
     ({ id, icon, handleAction, tooltipText, alwaysEnabled, isDisabled, isVisible, ...rest }) => {
       return (
         <ActionWithDropdown
+          alwaysEnabled={alwaysEnabled}
           columnPinning={columnPinning}
           enableColumnPinning={enableColumnPinning}
-          key={id}
-          isVisible={isVisible}
-          alwaysEnabled={alwaysEnabled}
-          isDisabled={isDisabled}
-          tooltipText={tooltipText}
-          icon={icon}
           handleAction={handleAction}
-          table={table}
-          testPrefix={testPrefix}
-          selectedRows={selectedRows}
+          icon={icon}
+          isDisabled={isDisabled}
           isOpen={isOpen}
+          isVisible={isVisible}
+          key={id}
           onClose={onClose}
+          selectedRows={selectedRows}
+          table={table}
+          tooltipText={tooltipText}
+          testPrefix={testPrefix}
           {...rest}
         />
       )
@@ -72,21 +72,21 @@ const makeColumnVisibilityAction = ({ handleAction, visible }) => ({
 const makeBulkActions = ({
   bulkActions,
   columnPinning,
+  columnVisibilityOptions,
   enableColumnPinning,
+  selectedRows,
   table,
   testPrefix,
-  selectedRows,
-  columnVisibilityOptions,
 }) => {
   const columnVisibility = makeColumnVisibilityAction({ ...columnVisibilityOptions })
   const actionsWithDropdown = renderActionWithDropdown({
     actions: [columnVisibility],
     columnPinning,
     enableColumnPinning,
-    ...columnVisibilityOptions,
-    testPrefix,
-    table,
     selectedRows,
+    table,
+    testPrefix,
+    ...columnVisibilityOptions,
   })
 
   const availableBulkActions = Object.keys({ ...bulkActions }).reduce((acc, currentActionKey) => {

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -93,12 +93,14 @@ const NetdataTable = ({
   const renderBulkActions = () => {
     const bulkActionsArray = [
       makeBulkActions({
+        columnPinning,
         columnVisibilityOptions: {
           isOpen: isColumnDropdownVisible,
           onClose: () => setIsColumnDropdownVisible(false),
           handleAction: () => setIsColumnDropdownVisible(true),
           visible: enableColumnVisibility,
         },
+        enableColumnPinning,
         bulkActions,
         testPrefix,
         table,

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -90,26 +90,22 @@ const NetdataTable = ({
 
   const makeActionsColumn = useMemo(() => makeRowActions({ rowActions, testPrefix }), [rowActions])
 
-  const renderBulkActions = () => {
-    const bulkActionsArray = [
-      makeBulkActions({
-        columnPinning,
-        columnVisibilityOptions: {
-          isOpen: isColumnDropdownVisible,
-          onClose: () => setIsColumnDropdownVisible(false),
-          handleAction: () => setIsColumnDropdownVisible(true),
-          visible: enableColumnVisibility,
-        },
-        enableColumnPinning,
-        bulkActions,
-        testPrefix,
-        table,
-        selectedRows: originalSelectedRows,
-      }),
-    ]
-
-    return bulkActionsArray
-  }
+  const renderBulkActions = () => [
+    makeBulkActions({
+      bulkActions,
+      columnPinning,
+      columnVisibilityOptions: {
+        handleAction: () => setIsColumnDropdownVisible(true),
+        isOpen: isColumnDropdownVisible,
+        onClose: () => setIsColumnDropdownVisible(false),
+        visible: enableColumnVisibility,
+      },
+      enableColumnPinning,
+      selectedRows: originalSelectedRows,
+      table,
+      testPrefix,
+    }),
+  ]
 
   const makeSelectionColumn = enableSelection ? [makeRowSelection({ testPrefix })] : []
 


### PR DESCRIPTION
This PR updates the UI of the dropdown menu to align with the dropdown presented on the [designs](https://www.figma.com/file/8flv50S2jhwiKMad04swLa/Functions?node-id=20%3A6741&t=Z4vwPlPSxHDpo6c5-0)

#### Solution
* Update styles of `ColumnsMenu`
* Update `ColumnsMenu` to support pinned columns and display them as `disabled`
* Update `Checkbox` component globally (change size and add disabled state for label)
* Update `Drop` optional props

#### Note
Since I have made some minor rearrangement of the props, if you feel like there are lots of changes to handle, please check per commit 