### PR TITLE
Wait for animation to render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.7.6",
+  "version": "2.8.0",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [


### PR DESCRIPTION
a little hacky way to solve https://github.com/netdata/netdata-cloud/issues/662

Problem is that when opening anomalyBit (as shown in https://github.com/netdata/netdata-cloud/issues/662#issuecomment-1361556555), there's 150 ms animation. Normally the chart fetches data slower than animation finishes, but when user opens the animalyBit for the second time - chart is ready instantly, and the animation for Collapsible just starts. Dygraph doesn't work properly in this case (tries to render when the `height` is 0) and creates chart with default width/height, that's why it doesn't look synchronized, because it takes only about half of the parent width)

I see 3 ways of fixing this issue:
1. remove animation from collapsible for anomalyBit
2. add `waitForAnimationToRender` option to Collapsible (this is this fix, the downside is that the component will be harder to maintain). It appends empty div with preset height during animation, instead of the child. When animation finishes, renders the content. Doesn't support width yet
3. fix this in dygraph. Probably ideal way, but I just didn't wanted to spend more time fighting with this issue.