### PR TITLE
fix radioButton disabled colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.8.11",
+  "version": "2.8.11-dev.1",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.8.11-dev.1",
+  "version": "2.8.12",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/radio-button/index.js
+++ b/src/components/radio-button/index.js
@@ -1,9 +1,13 @@
 import React from "react"
 import { Text } from "src/components/typography"
-import { Input, Container, IconContainer, StyledIcon } from "./styled"
+import { Container, IconContainer, Input, StyledIcon } from "./styled"
 
 const radioButtonStyles = {
-  disabled: { containerColor: "disabled", dotColor: "disabled", borderColor: "disabled" },
+  disabled: {
+    containerColor: "disabledBackground",
+    dotColor: "disabledBackground",
+    borderColor: "disabledBackground",
+  },
   checked: { containerColor: "inputBg", dotColor: "primary", borderColor: "inputBorder" },
   checkedDisabled: { containerColor: "inputBg", dotColor: "disabled", borderColor: "inputBorder" },
   default: { containerColor: "inputBg", dotColor: "bright", borderColor: "inputBorder" },

--- a/src/components/radio-button/styled.js
+++ b/src/components/radio-button/styled.js
@@ -31,6 +31,7 @@ export const IconContainer = styled.div`
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  flex: 0 0 auto;
 
   height: 20px;
   width: 20px;


### PR DESCRIPTION
Fixed radio-button disabled color, we'll use it only in setRole dialog, and dialog's background had the same color as old radio 
disabled state.

New:
![image](https://user-images.githubusercontent.com/5786722/215471441-0e20d135-12ed-411d-9733-77e23df19b62.png)

@christophidesp It's just something i needed to do quickly, please let me know if you'll want different colors