### PR TITLE
chore(select): add support for data attributes of Select component

### DIFF
--- a/src/components/select/index.d.ts
+++ b/src/components/select/index.d.ts
@@ -1,0 +1,13 @@
+import { FC } from "react"
+import { Props } from "react-select"
+
+export interface SelectProps extends Props {
+  "data-ga"?: string;
+  "data-testid"?: string;
+}
+
+declare const Select: FC<SelectProps>
+
+export { Select }
+
+export default Select

--- a/src/components/select/index.js
+++ b/src/components/select/index.js
@@ -1,5 +1,91 @@
-import ReactSelect from "react-select"
+import React from "react"
 import styled from "styled-components"
+import ReactSelect, { components } from "react-select"
+import { capitalizeFirstLetter } from "@/lib/glue/utils"
+
+const addDataAttrs =
+  (Component, { ga, testId }) =>
+    props =>
+      (
+        <Component
+          {...props}
+          innerProps={Object.assign({}, props.innerProps, {
+            ...(ga ? { "data-ga": ga } : {}),
+            ...(testId ? { "data-testid": testId } : {}),
+          })}
+        />
+      )
+
+const makeDataAttrs = (ga, testId) => type => {
+  const dataAttrs = {}
+
+  if (ga) {
+    const gaParts = ga.split("::")
+    gaParts[1] = `${gaParts[1]}-${type}`
+    dataAttrs.ga = gaParts.join("::")
+  }
+
+  if (testId) {
+    dataAttrs.testId = `${testId}${capitalizeFirstLetter(type)}`
+  }
+
+  return dataAttrs
+}
+
+const makeCustomComponents = makeComponentDataAttrs => ({
+  ClearIndicator: addDataAttrs(components.ClearIndicator, makeComponentDataAttrs("clearIndicator")),
+  Control: addDataAttrs(components.Control, makeComponentDataAttrs("clearIndicator")),
+  DropdownIndicator: addDataAttrs(
+    components.DropdownIndicator,
+    makeComponentDataAttrs("dropdownIndicator")
+  ),
+  DownChevron: addDataAttrs(components.DownChevron, makeComponentDataAttrs("downChevron")),
+  CrossIcon: addDataAttrs(components.CrossIcon, makeComponentDataAttrs("crossIcon")),
+  Group: addDataAttrs(components.Group, makeComponentDataAttrs("group")),
+  GroupHeading: addDataAttrs(components.GroupHeading, makeComponentDataAttrs("groupHeading")),
+  IndicatorsContainer: addDataAttrs(
+    components.IndicatorsContainer,
+    makeComponentDataAttrs("indicatorsContainer")
+  ),
+  IndicatorSeparator: addDataAttrs(
+    components.IndicatorSeparator,
+    makeComponentDataAttrs("indicatorSeparator")
+  ),
+  Input: addDataAttrs(components.Input, makeComponentDataAttrs("input")),
+  LoadingIndicator: addDataAttrs(
+    components.LoadingIndicator,
+    makeComponentDataAttrs("loadingIndicator")
+  ),
+  Menu: addDataAttrs(components.Menu, makeComponentDataAttrs("menu")),
+  MenuList: addDataAttrs(components.MenuList, makeComponentDataAttrs("menuList")),
+  MenuPortal: addDataAttrs(components.MenuPortal, makeComponentDataAttrs("menuPortal")),
+  LoadingMessage: addDataAttrs(components.LoadingMessage, makeComponentDataAttrs("loadingMessage")),
+  NoOptionsMessage: addDataAttrs(
+    components.NoOptionsMessage,
+    makeComponentDataAttrs("noOptionsMessage")
+  ),
+  MultiValue: addDataAttrs(components.MultiValue, makeComponentDataAttrs("multiValue")),
+  MultiValueContainer: addDataAttrs(
+    components.MultiValueContainer,
+    makeComponentDataAttrs("multiValueContainer")
+  ),
+  MultiValueLabel: addDataAttrs(
+    components.MultiValueLabel,
+    makeComponentDataAttrs("multiValueLabel")
+  ),
+  MultiValueRemove: addDataAttrs(
+    components.MultiValueRemove,
+    makeComponentDataAttrs("multiValueRemove")
+  ),
+  Option: addDataAttrs(components.Option, makeComponentDataAttrs("option")),
+  Placeholder: addDataAttrs(components.Placeholder, makeComponentDataAttrs("placeholder")),
+  SelectContainer: addDataAttrs(
+    components.SelectContainer,
+    makeComponentDataAttrs("selectContainer")
+  ),
+  SingleValue: addDataAttrs(components.SingleValue, makeComponentDataAttrs("singleValue")),
+  ValueContainer: addDataAttrs(components.ValueContainer, makeComponentDataAttrs("valueContainer")),
+})
 
 const makeCustomTheme = theme => selectTheme => {
   return {
@@ -41,26 +127,29 @@ const makeCustomStyles = (theme, { size, ...providedStyles } = {}) => ({
       borderColor: theme.colors.inputBorderHover,
     },
   }),
-  input: (styles, state) =>({
+  input: (styles, state) => ({
     ...styles,
     color: state.isDisabled ? theme.colors.placeholder : theme.colors.textDescription,
-    ...(size === "tiny" ? {
-      lineHeight: "18px",
-      paddingBottom: 0,
-      paddingTop: 0
-    } : {}),
+    ...(size === "tiny"
+      ? {
+        lineHeight: "18px",
+        paddingBottom: 0,
+        paddingTop: 0,
+      }
+      : {}),
   }),
   menu: styles => ({ ...styles, zIndex: 100 }),
   menuPortal: styles => ({ ...styles, zIndex: 9999 }),
-  multiValue: (styles) => ({
+  multiValue: styles => ({
     ...styles,
     fontSize: size === "tiny" ? "12px" : "14px",
+    flexDirection: "row-reverse",
     ...(size === "tiny" ? { minHeight: 18 } : {}),
   }),
   multiValueLabel: (styles, state) => ({
     ...styles,
     backgroundColor: theme.colors.disabled,
-    borderRadius: "2px 0 0 2px",
+    borderRadius: "0 2px 2px 0",
     color: state.isDisabled ? theme.colors.placeholder : theme.colors.textDescription,
     ...(size === "tiny" ? { padding: "1px" } : {}),
     paddingRight: state.data.isDisabled ? "8px" : "",
@@ -71,10 +160,10 @@ const makeCustomStyles = (theme, { size, ...providedStyles } = {}) => ({
       ? { ...styles, display: "none" }
       : {
         ...styles,
-        borderRadius: "0 2px 2px 0",
+        borderRadius: "2px 0 0 2px",
         background: theme.colors.disabled,
         ":hover": {
-          background: theme.colors.borderSecondary,
+          background: theme.colors.tabsBorder,
         },
       }),
   }),
@@ -86,14 +175,12 @@ const makeCustomStyles = (theme, { size, ...providedStyles } = {}) => ({
   placeholder: styles => ({
     ...styles,
     color: theme.colors.placeholder,
-    ...(size === "tiny"
-      ? { fontSize: "12px", lineHeight: "18px" }
-      : {})
+    ...(size === "tiny" ? { fontSize: "12px", lineHeight: "18px" } : {}),
   }),
   singleValue: (styles, state) => ({
     ...styles,
     color: state.isDisabled ? theme.colors.placeholder : theme.colors.textDescription,
-    fontSize: size === "tiny" ? "12px" : "14px"
+    fontSize: size === "tiny" ? "12px" : "14px",
   }),
   ...(size === "tiny"
     ? {
@@ -110,9 +197,13 @@ const makeCustomStyles = (theme, { size, ...providedStyles } = {}) => ({
   ...providedStyles,
 })
 
-// @TODO check react-select for rendering data attributes
-export const Select = styled(ReactSelect).attrs(props => ({
-  ...props,
-  theme: makeCustomTheme(props.theme),
-  styles: makeCustomStyles(props.theme, props.styles),
-}))``
+const Select = styled(ReactSelect).attrs(
+  ({ "data-ga": ga, "data-testid": testId, ...props }) => ({
+    ...props,
+    components: makeCustomComponents(makeDataAttrs(ga, testId)),
+    theme: makeCustomTheme(props.theme),
+    styles: makeCustomStyles(props.theme, props.styles),
+  })
+)``
+
+export default Select

--- a/src/components/tableV2/components/dropdownFilter.js
+++ b/src/components/tableV2/components/dropdownFilter.js
@@ -1,21 +1,16 @@
 import React from "react"
+import Select from "src/components/select"
 
-import { Select } from "src/components/select"
-
-const DropdownFilter = ({ onChange, value, options, isMulti, styles }) => {
-  const selectedValue = value
-
-  return (
-    <Select
-      isMulti={isMulti}
-      options={options}
-      value={selectedValue}
-      onChange={option => {
-        onChange(option)
-      }}
-      styles={styles}
-    />
-  )
-}
+const DropdownFilter = ({ onChange, value, options, isMulti, styles }) => (
+  <Select
+    isMulti={isMulti}
+    options={options}
+    value={value}
+    onChange={option => {
+      onChange(option)
+    }}
+    styles={styles}
+  />
+)
 
 export default DropdownFilter

--- a/src/components/tableV2/features/useRowActions.js
+++ b/src/components/tableV2/features/useRowActions.js
@@ -68,27 +68,25 @@ export default (rowActions, { testPrefix } = {}) => {
     enableHiding: false,
     enableResizing: false,
     header: "Actions",
-    cell: ({ row, table }) => {
-      return (
-        <Flex data-testid="action-cell" height="100%" gap={2}>
-          {availableRowActions.map(
-            ({ id, handleAction, isDisabled, isVisible = true, dataGa, ...rest }) => (
-              <Action
-                {...rest}
-                disabled={typeof isDisabled === "function" ? isDisabled(row.original) : isDisabled}
-                visible={typeof isVisible === "function" ? isVisible(row.original) : isVisible}
-                dataGa={typeof dataGa === "function" ? dataGa(row.original) : dataGa}
-                key={id}
-                id={id}
-                handleAction={() => handleAction(row.original, table)}
-                testPrefix={testPrefix}
-                currentRow={row}
-              />
-            )
-          )}
-        </Flex>
-      )
-    },
+    cell: ({ row, table }) => (
+      <Flex data-testid="action-cell" height="100%" gap={2}>
+        {availableRowActions.map(
+          ({ id, handleAction, isDisabled, isVisible = true, dataGa, ...rest }) => (
+            <Action
+              {...rest}
+              disabled={typeof isDisabled === "function" ? isDisabled(row.original) : isDisabled}
+              visible={typeof isVisible === "function" ? isVisible(row.original) : isVisible}
+              dataGa={typeof dataGa === "function" ? dataGa(row.original) : dataGa}
+              key={id}
+              id={id}
+              handleAction={() => handleAction(row.original, table)}
+              testPrefix={testPrefix}
+              currentRow={row}
+            />
+          )
+        )}
+      </Flex>
+    ),
     enableColumnFilter: false,
     enableSorting: false,
     meta: { stopPropagation: true },

--- a/src/index.js
+++ b/src/index.js
@@ -117,3 +117,5 @@ export { default as Modal } from "./components/modal"
 export { ConfirmationDialog } from "./components/confirmation-dialog"
 
 export { NetdataTable } from "./components/tableV2"
+
+export { default as Select } from "./components/select"


### PR DESCRIPTION
This PR resolves issue [Cloud Frontend #3972](https://github.com/netdata/cloud-frontend/issues/3972) and partially resolves issue [Cloud Frontend #3971](https://github.com/netdata/cloud-frontend/issues/3971)

#### Solution
* Add support for `data-ga` and `data-testid` for `Select` component
* Export `Select` component from `@netdata/netdata-ui` library
* Minor updates