### PR TITLE
Loading state on confirmation dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ export const MyComponent: FC<PropsT> = (props: PropsT) => <>...</>
 
 You can find latest **master** storybook playground [here](https://netdata.github.io/netdata-ui/)
 
+## Local development
+
+First, install the dependencies
+```
+yarn
+```
+
+then, build the project and start
+```
+yarn build && yarn start
+```
+
+Open your browser to [localhost:6006](http://localhost:6006) and view the storybook locally.
+
+
 ## Components
 
 - [Theme and theme utils](https://github.com/netdata/netdata-ui/blob/master/src/theme)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/confirmation-dialog/confirmation-dialog.js
+++ b/src/components/confirmation-dialog/confirmation-dialog.js
@@ -2,6 +2,7 @@ import React from "react"
 import Flex from "src/components/templates/flex"
 import { Button } from "src/components/button"
 import { Text } from "src/components/typography"
+import useToggle from "react-use/lib/useToggle"
 import { Actions, Body, CloseButton, Content, Dialog, Header, Title, TitleIcon } from "./styled"
 
 const BodyMessage = ({ children, ...rest }) =>
@@ -9,6 +10,7 @@ const BodyMessage = ({ children, ...rest }) =>
 
 const ConfirmationDialog = ({
   confirmLabel = "Yes, remove",
+  confirmLoadingLabel = "Loading...",
   confirmWidth = "128px",
   "data-ga": dataGA = "confirmation-dialog",
   "data-testid": dataTestId = "confirmationDialog",
@@ -22,7 +24,16 @@ const ConfirmationDialog = ({
   isConfirmPositive,
   message,
   title,
+  showConfirmLoading,
+  disableConfirmOnLoading,
 }) => {
+  const [loading, toggleLoading] = useToggle(false)
+
+  const onConfirm = e => {
+    if (showConfirmLoading) toggleLoading()
+    handleConfirm(e, toggleLoading)
+  }
+
   return (
     <Dialog onEsc={handleDecline}>
       <Content data-testid={dataTestId}>
@@ -53,10 +64,11 @@ const ConfirmationDialog = ({
             data-ga={`${dataGA}-::click-confirm::global-view`}
             data-testid={`${dataTestId}-confirmAction`}
             danger={!isConfirmPositive && true}
-            disabled={isConfirmDisabled}
-            label={confirmLabel}
-            onClick={handleConfirm}
+            disabled={isConfirmDisabled || (disableConfirmOnLoading && loading)}
+            label={loading ? confirmLoadingLabel : confirmLabel}
+            onClick={onConfirm}
             width={confirmWidth}
+            isLoading={loading}
           />
         </Actions>
       </Content>

--- a/src/components/confirmation-dialog/confirmation-dialog.stories.js
+++ b/src/components/confirmation-dialog/confirmation-dialog.stories.js
@@ -19,3 +19,22 @@ Story.add("Confirmation dialog", () => {
     />
   )
 })
+
+Story.add("Confirmation dialog with loading", () => {
+  return (
+    <ConfirmationDialog
+      confirmLabel="Yes"
+      declineLabel="Please don't!"
+      handleConfirm={(_, toggleLoading) => {
+        console.log("Pressed confirm")
+        setTimeout(() => toggleLoading(), 2000)
+      }}
+      handleDecline={() => alert("Pressed decline")}
+      isConfirmPositive={boolean("isConfirmPositive", false)}
+      message="We are about to fulfill your request, there is no return from here. Are you sure?"
+      title="Are you sure you want to proceed?"
+      showConfirmLoading={boolean("showConfirmLoading", false)}
+      disableConfirmOnLoading={boolean("disableConfirmOnLoading", true)}
+    />
+  )
+})

--- a/src/components/confirmation-dialog/confirmation-dialog.stories.js
+++ b/src/components/confirmation-dialog/confirmation-dialog.stories.js
@@ -33,7 +33,7 @@ Story.add("Confirmation dialog with loading", () => {
       isConfirmPositive={boolean("isConfirmPositive", false)}
       message="We are about to fulfill your request, there is no return from here. Are you sure?"
       title="Are you sure you want to proceed?"
-      showConfirmLoading={boolean("showConfirmLoading", false)}
+      showConfirmLoading={boolean("showConfirmLoading", true)}
       disableConfirmOnLoading={boolean("disableConfirmOnLoading", true)}
     />
   )


### PR DESCRIPTION
This PR adds the ability to configure the appearance of a loader when the confirm button is clicked on the confirmation dialog.

The loader can be toggled from inside the `handleConfirm` function, since it (the `handleConfirm`) gets a `toggleLoading` function as it's second argument.