### PR TITLE
fix header-cell dropdowns (for example from filter/select)

### DIFF
--- a/src/components/tableV2/core/base-table.js
+++ b/src/components/tableV2/core/base-table.js
@@ -121,7 +121,6 @@ Table.HeadCell = forwardRef(
           fontSize: "14px",
         }}
         position="relative"
-        overflow="hidden"
         padding={[1, 2]}
         width={`${width}px`}
         onMouseEnter={() => onHover({ row: null, column: id })}


### PR DESCRIPTION
fixes https://github.com/netdata/netdata-cloud/issues/783

But I'm not sure why overflow="hidden" was set here in the first place, so perhaps this issue needs a different solution.
cc @novykh , i see you did that change

a duplicate of https://github.com/netdata/netdata-ui/pull/457, which i later reverted, because I'm not 100% sure it's ready to be merged