### PR TITLE
fix(netdata table): remove useCallback from onSorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -97,10 +97,13 @@ const NetdataTable = forwardRef(
       setSorting(sortBy)
     }, [sortBy])
 
-    const onShorting = getSorting => {
-      onSortingChange(getSorting)
-      setSorting(getSorting)
-    }
+    const onShorting = useCallback(
+      getSorting => {
+        onSortingChange(getSorting)
+        setSorting(getSorting)
+      },
+      [sortBy]
+    )
 
     const [pagination, setPagination] = useState(() => ({
       pageIndex: paginationOptions.pageIndex,

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -97,10 +97,10 @@ const NetdataTable = forwardRef(
       setSorting(sortBy)
     }, [sortBy])
 
-    const onShorting = useCallback(getSorting => {
+    const onShorting = getSorting => {
       onSortingChange(getSorting)
       setSorting(getSorting)
-    }, [])
+    }
 
     const [pagination, setPagination] = useState(() => ({
       pageIndex: paginationOptions.pageIndex,

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -102,7 +102,7 @@ const NetdataTable = forwardRef(
         onSortingChange(getSorting)
         setSorting(getSorting)
       },
-      [sortBy]
+      [onSortingChange]
     )
 
     const [pagination, setPagination] = useState(() => ({


### PR DESCRIPTION
This PR removes `useCallback` from sorting handler of table, in order for the user to be able to regenerate the function passed when needed attribute values have been altered