### PR TITLE
Add right column pinning to table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "2.16.6",
+  "version": "2.16.7",
   "description": "netdata UI kit",
   "main": "./lib/index.js",
   "files": [

--- a/src/components/tableV2/core/base-table.js
+++ b/src/components/tableV2/core/base-table.js
@@ -241,7 +241,18 @@ Table.Body = forwardRef(({ children, ...props }, ref) => (
 
 Table.Cell = forwardRef(
   (
-    { align = "left", children, onClick, width, isRowHovering, index, meta, tableMeta, ...rest },
+    {
+      align = "left",
+      children,
+      onClick,
+      width,
+      isRowHovering,
+      index,
+      meta,
+      tableMeta,
+      cellHeight = "65px",
+      ...rest
+    },
     ref
   ) => {
     const handleClick = e => {
@@ -269,7 +280,7 @@ Table.Cell = forwardRef(
         backgroundOpacity={
           isRowHovering ? (rest.backgroundOpacity ? 0.8 : 1) : rest.backgroundOpacity || 0.7
         }
-        height="65px"
+        height={cellHeight}
         {...tableMeta?.cellStyles}
         {...tableMeta?.pinnedStyles}
         {...tableMeta?.styles}

--- a/src/components/tableV2/core/fullTable.js
+++ b/src/components/tableV2/core/fullTable.js
@@ -22,6 +22,7 @@ const FullTable = ({
   virtualizeOptions = {},
   coloredSortedColumn,
   meta,
+  side,
   ...rest
 }) => {
   return (
@@ -66,6 +67,8 @@ const FullTable = ({
           testPrefixCallback={testPrefixCallback}
           coloredSortedColumn={enableSorting && coloredSortedColumn}
           meta={meta}
+          enableColumnPinning={rest.enableColumnPinning}
+          side={side}
           {...virtualizeOptions}
         />
       </Table.Body>

--- a/src/components/tableV2/core/row.js
+++ b/src/components/tableV2/core/row.js
@@ -1,0 +1,82 @@
+import React, { useRef, useLayoutEffect } from "react"
+import { flexRender } from "@tanstack/react-table"
+import { useTableContext } from "../features/provider"
+import Table from "./base-table"
+
+export default ({
+  table,
+  pinnedStyles,
+  row,
+  virtualRow,
+  onClickRow,
+  disableClickRow,
+  testPrefix,
+  testPrefixCallback,
+  getRowHandler,
+  onHover,
+  coloredSortedColumn,
+  hoveredRow,
+  enableColumnPinning,
+  side,
+}) => {
+  const ref = useRef()
+  const cells = row[getRowHandler]()
+  const { rowsHeight, setRowHeight } = useTableContext()
+  const rowHeight = rowsHeight[virtualRow.index]
+
+  useLayoutEffect(() => {
+    if (enableColumnPinning || ["left", "right"].includes(side)) {
+      const height = ref.current?.clientHeight || 0
+      setRowHeight({ index: virtualRow.index, height })
+    }
+  }, [])
+
+  return (
+    <Table.Row
+      key={virtualRow.key}
+      data-testid={`netdata-table-row${testPrefix}${
+        testPrefixCallback ? "-" + testPrefixCallback(row.original) : ""
+      }`}
+      onClick={
+        onClickRow
+          ? () => onClickRow({ data: row.original, table: table, fullRow: row })
+          : undefined
+      }
+      disableClickRow={() => disableClickRow?.({ data: row.original, table: table, fullRow: row })}
+      ref={ref}
+      {...(rowHeight ? { height: `${rowHeight}px` } : {})}
+    >
+      {cells.map((cell, index) => (
+        <Table.Cell
+          key={cell.column.columnDef.id}
+          data-testid={`netdata-table-cell-${cell.column.columnDef.id}${testPrefix}`}
+          pinnedStyles={index === cells.length - 1 ? pinnedStyles : {}}
+          width={cell.column.getSize()}
+          onMouseEnter={() => onHover({ row: row.id, column: cell.column.id })}
+          onMouseLeave={() => onHover()}
+          tableMeta={
+            typeof cell.column.columnDef.tableMeta === "function"
+              ? cell.column.columnDef.tableMeta(row, cell, index)
+              : cell.column.columnDef.tableMeta
+          }
+          meta={
+            typeof cell.column.columnDef.meta === "function"
+              ? cell.column.columnDef.meta(row)
+              : cell.column.columnDef.meta
+          }
+          {...(cell.column.getCanSort() &&
+            coloredSortedColumn &&
+            !!cell.column.getIsSorted() && {
+              background: "columnHighlight",
+              backgroundOpacity: virtualRow.index % 2 == 0 ? "0.2" : "0.4",
+            })}
+          index={virtualRow.index}
+          isRowHovering={row.id === hoveredRow}
+          {...(enableColumnPinning ? { cellHeight: `${rowHeight}px` } : {})}
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </Table.Cell>
+      ))}
+    </Table.Row>
+  )
+}

--- a/src/components/tableV2/core/rows.js
+++ b/src/components/tableV2/core/rows.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo } from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import { flexRender } from "@tanstack/react-table"
 import { useTableContext } from "../features/provider"
-import Table from "./base-table"
+import Row from "./row"
 
 const Rows = ({
   disableClickRow,
@@ -19,6 +18,8 @@ const Rows = ({
   loadMore,
   coloredSortedColumn,
   meta,
+  enableColumnPinning,
+  side,
 }) => {
   const { onHover, hoveredRow } = useTableContext()
 
@@ -64,54 +65,25 @@ const Rows = ({
       )}
       {virtualRows.map(virtualRow => {
         const row = rows[virtualRow.index]
-        const cells = row[getRowHandler]()
 
         return (
-          <Table.Row
+          <Row
             key={virtualRow.key}
-            data-testid={`netdata-table-row${testPrefix}${
-              testPrefixCallback ? "-" + testPrefixCallback(row.original) : ""
-            }`}
-            onClick={
-              onClickRow
-                ? () => onClickRow({ data: row.original, table: table, fullRow: row })
-                : undefined
-            }
-            disableClickRow={() =>
-              disableClickRow?.({ data: row.original, table: table, fullRow: row })
-            }
-          >
-            {cells.map((cell, index) => (
-              <Table.Cell
-                key={cell.column.columnDef.id}
-                data-testid={`netdata-table-cell-${cell.column.columnDef.id}${testPrefix}`}
-                pinnedStyles={index === cells.length - 1 ? pinnedStyles : {}}
-                width={cell.column.getSize()}
-                onMouseEnter={() => onHover({ row: row.id, column: cell.column.id })}
-                onMouseLeave={() => onHover()}
-                tableMeta={
-                  typeof cell.column.columnDef.tableMeta === "function"
-                    ? cell.column.columnDef.tableMeta(row, cell, index)
-                    : cell.column.columnDef.tableMeta
-                }
-                meta={
-                  typeof cell.column.columnDef.meta === "function"
-                    ? cell.column.columnDef.meta(row)
-                    : cell.column.columnDef.meta
-                }
-                {...(cell.column.getCanSort() &&
-                  coloredSortedColumn &&
-                  !!cell.column.getIsSorted() && {
-                    background: "columnHighlight",
-                    backgroundOpacity: virtualRow.index % 2 == 0 ? "0.2" : "0.4",
-                  })}
-                index={virtualRow.index}
-                isRowHovering={row.id === hoveredRow}
-              >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </Table.Cell>
-            ))}
-          </Table.Row>
+            table={table}
+            pinnedStyles={pinnedStyles}
+            row={row}
+            virtualRow={virtualRow}
+            onClickRow={onClickRow}
+            disableClickRow={disableClickRow}
+            testPrefix={testPrefix}
+            testPrefixCallback={testPrefixCallback}
+            getRowHandler={getRowHandler}
+            onHover={onHover}
+            coloredSortedColumn={coloredSortedColumn}
+            hoveredRow={hoveredRow}
+            enableColumnPinning={enableColumnPinning}
+            side={side}
+          />
         )
       })}
 

--- a/src/components/tableV2/features/columnPinning.js
+++ b/src/components/tableV2/features/columnPinning.js
@@ -14,16 +14,21 @@ const ColumnPinning = ({
   testPrefix,
   testPrefixCallback,
   scrollParentRef,
+  side,
   ...rest
 }) => {
   const getThemeColor = useColor()
+  const isLeft = side == "left"
+  const getRowHandler = isLeft ? "getLeftVisibleCells" : "getRightVisibleCells"
+  const borderSide = isLeft ? "borderRight" : "borderLeft"
+  const getTotalSizeFunc = isLeft ? "getLeftTotalSize" : "getRightTotalSize"
 
   return (
     <Box
       background="mainBackground"
       sx={{
         position: "sticky",
-        left: 0,
+        [side]: 0,
         zIndex: 11,
         height: "fit-content",
       }}
@@ -34,14 +39,14 @@ const ColumnPinning = ({
         disableClickRow={disableClickRow}
         enableResize={enableResize}
         enableSorting={enableSorting}
-        getRowHandler="getLeftVisibleCells"
+        getRowHandler={getRowHandler}
         onClickRow={onClickRow}
         onHoverCell={onHoverCell}
-        pinnedStyles={{ borderRight: `1px solid ${getThemeColor("borderSecondary")}` }}
+        pinnedStyles={{ [borderSide]: `1px solid ${getThemeColor("borderSecondary")}` }}
         table={table}
         testPrefix={`pin${testPrefix}`}
         testPrefixCallback={testPrefixCallback}
-        width={enableResize ? `${table.getLeftTotalSize()}px` : "100%"}
+        width={enableResize ? `${table[getTotalSizeFunc]()}px` : "100%"}
         {...rest}
       />
     </Box>

--- a/src/components/tableV2/features/columnPinning.js
+++ b/src/components/tableV2/features/columnPinning.js
@@ -47,6 +47,7 @@ const ColumnPinning = ({
         testPrefix={`pin${testPrefix}`}
         testPrefixCallback={testPrefixCallback}
         width={enableResize ? `${table[getTotalSizeFunc]()}px` : "100%"}
+        side={side}
         {...rest}
       />
     </Box>

--- a/src/components/tableV2/features/provider.js
+++ b/src/components/tableV2/features/provider.js
@@ -4,7 +4,7 @@ const TableContext = createContext({})
 
 export const useTableContext = () => useContext(TableContext)
 
-const initialState = { hoveredRow: null, hoveredColumn: null }
+const initialState = { hoveredRow: null, hoveredColumn: null, rowsHeight: {} }
 
 const TableProvider = ({ onHoverCell, children }) => {
   const [state, setState] = useState(initialState)
@@ -24,7 +24,17 @@ const TableProvider = ({ onHoverCell, children }) => {
     [onHoverCell]
   )
 
-  const contextValue = useMemo(() => ({ ...state, dispatch, onHover }), [state, onHover])
+  const setRowHeight = useCallback(({ index, height }) => {
+    setState(prev => ({
+      ...prev,
+      rowsHeight: { ...prev.rowsHeight, [index]: Math.max(prev.rowsHeight[index] || 0, height) },
+    }))
+  }, [])
+
+  const contextValue = useMemo(
+    () => ({ ...state, dispatch, onHover, setRowHeight }),
+    [state, onHover]
+  )
 
   return <TableContext.Provider value={contextValue}>{children}</TableContext.Provider>
 }

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -215,8 +215,9 @@ const NetdataTable = forwardRef(
             />
           ) : null}
           <Flex row ref={scrollParentRef} overflow="auto">
-            {enableColumnPinning && (
+            {enableColumnPinning && columnPinning.left && (
               <ColumnPinning
+                side="left"
                 enableResize={enableResize}
                 onClickRow={onClickRow}
                 enableSorting={enableSorting}
@@ -245,6 +246,21 @@ const NetdataTable = forwardRef(
               meta={tableMeta}
               {...rest}
             />
+            {enableColumnPinning && columnPinning.right && (
+              <ColumnPinning
+                side="right"
+                enableResize={enableResize}
+                onClickRow={onClickRow}
+                enableSorting={enableSorting}
+                table={table}
+                headers={table.getRightHeaderGroups()}
+                testPrefix={testPrefix}
+                dataGa={dataGa}
+                scrollParentRef={scrollParentRef}
+                virtualizeOptions={virtualizeOptions}
+                meta={tableMeta}
+              />
+            )}
           </Flex>
           {!hasNextPage && !loading && !!warning && (
             <Flex alignItems="center" justifyContent="center" gap={2} padding={[4]} width="100%">

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -244,6 +244,7 @@ const NetdataTable = forwardRef(
               testPrefix={testPrefix}
               virtualizeOptions={virtualizeOptions}
               meta={tableMeta}
+              side="center"
               {...rest}
             />
             {enableColumnPinning && columnPinning.right && (

--- a/src/components/tableV2/netdataTable.js
+++ b/src/components/tableV2/netdataTable.js
@@ -199,6 +199,33 @@ const NetdataTable = forwardRef(
       testPrefix,
     })
 
+    const columnPinningProps = useCallback(
+      side => ({
+        side,
+        enableResize,
+        onClickRow,
+        enableSorting,
+        table,
+        headers: side == "left" ? table.getLeftHeaderGroups() : table.getRightHeaderGroups(),
+        testPrefix,
+        dataGa,
+        scrollParentRef,
+        virtualizeOptions,
+        meta: tableMeta,
+      }),
+      [
+        enableResize,
+        onClickRow,
+        enableSorting,
+        table,
+        testPrefix,
+        dataGa,
+        scrollParentRef,
+        virtualizeOptions,
+        tableMeta,
+      ]
+    )
+
     const { hasNextPage, loading, warning } = virtualizeOptions || {}
 
     return (
@@ -216,19 +243,7 @@ const NetdataTable = forwardRef(
           ) : null}
           <Flex row ref={scrollParentRef} overflow="auto">
             {enableColumnPinning && columnPinning.left && (
-              <ColumnPinning
-                side="left"
-                enableResize={enableResize}
-                onClickRow={onClickRow}
-                enableSorting={enableSorting}
-                table={table}
-                headers={table.getLeftHeaderGroups()}
-                testPrefix={testPrefix}
-                dataGa={dataGa}
-                scrollParentRef={scrollParentRef}
-                virtualizeOptions={virtualizeOptions}
-                meta={tableMeta}
-              />
+              <ColumnPinning {...columnPinningProps("left")} />
             )}
             <FullTable
               headers={columnPinning ? table.getCenterHeaderGroups() : table.getHeaderGroups()}
@@ -248,19 +263,7 @@ const NetdataTable = forwardRef(
               {...rest}
             />
             {enableColumnPinning && columnPinning.right && (
-              <ColumnPinning
-                side="right"
-                enableResize={enableResize}
-                onClickRow={onClickRow}
-                enableSorting={enableSorting}
-                table={table}
-                headers={table.getRightHeaderGroups()}
-                testPrefix={testPrefix}
-                dataGa={dataGa}
-                scrollParentRef={scrollParentRef}
-                virtualizeOptions={virtualizeOptions}
-                meta={tableMeta}
-              />
+              <ColumnPinning {...columnPinningProps("right")} />
             )}
           </Flex>
           {!hasNextPage && !loading && !!warning && (

--- a/src/components/tableV2/netdataTable.stories.js
+++ b/src/components/tableV2/netdataTable.stories.js
@@ -483,3 +483,112 @@ tableStories.add("Full Table functionallity", () => {
     </Box>
   )
 })
+
+tableStories.add("With Pinning", () => {
+  const mockDataColumns = [
+    {
+      accessorKey: "nodes",
+      header: "Nodes",
+      id: "nodes",
+      cell: ({ getValue }) => getValue(),
+      enableHiding: false,
+    },
+    {
+      accessorKey: "alerts",
+      id: "alerts",
+      header: () => <Text>Alerts</Text>,
+      cell: ({ getValue }) => getValue(),
+      size: 340,
+    },
+    {
+      accessorKey: "user",
+      header: "user",
+      id: "user",
+      cell: ({ getValue }) => getValue(),
+      size: 200,
+    },
+    {
+      accessorKey: "status",
+      header: "status",
+      id: "status",
+      size: 200,
+      cell: ({ getValue }) => getValue(),
+    },
+    {
+      accessorKey: "untouchable",
+      header: "Untouchable",
+      id: "untouchable",
+      size: 200,
+      cell: ({ getValue }) => getValue(),
+    },
+  ]
+
+  const mockData = () => [
+    {
+      nodes: "node31",
+      alerts: 15,
+      user: "mitsos",
+      disabled: true,
+      status: "stale",
+      untouchable: "true",
+    },
+    { nodes: "node0", alerts: 11, user: "koukouroukou", status: "offline", untouchable: "true" },
+    { nodes: "node1", alerts: 22, user: "reena", status: "online", untouchable: "true" },
+    { nodes: "node1", alerts: 15, user: "nic", status: "online", untouchable: "true" },
+    { nodes: "node2", alerts: 11, user: "alex", status: "offline", untouchable: "true" },
+    { nodes: "node3", alerts: 22, user: "manolis", status: "offline", untouchable: "true" },
+    { nodes: "node4", alerts: 15, user: "achile", status: "stale", untouchable: "true" },
+    { nodes: "node5", alerts: 11, user: "barba", status: "stale", untouchable: "false" },
+    { nodes: "node6", alerts: 22, user: "decker", status: "online", untouchable: "false" },
+    { nodes: "node7", alerts: 11, user: "koukouroukou, koukouroukou, koukouroukou, koukouroukou, koukouroukou", status: "offline", untouchable: "true" },
+    { nodes: "node8", alerts: 22, user: "reena", status: "online", untouchable: "true" },
+    { nodes: "node9", alerts: 15, user: "nic", status: "online", untouchable: "true" },
+    { nodes: "node10", alerts: 11, user: "alex", status: "offline", untouchable: "true" },
+    { nodes: "node11", alerts: 22, user: "manolis", status: "offline", untouchable: "true" },
+    { nodes: "node12", alerts: 15, user: "achile", status: "stale", untouchable: "true" },
+    { nodes: "node13", alerts: 11, user: "barba", status: "stale", untouchable: "false" },
+    { nodes: "node14", alerts: 22, user: "decker", status: "online", untouchable: "false" },
+    { nodes: "node15", alerts: 11, user: "koukouroukou", status: "offline", untouchable: "true" },
+    { nodes: "node16", alerts: 22, user: "reena", status: "online", untouchable: "true" },
+    { nodes: "node17", alerts: 15, user: "nic", status: "online", untouchable: "true" },
+    { nodes: "node18", alerts: 11, user: "alex", status: "offline", untouchable: "true" },
+    { nodes: "node19", alerts: 22, user: "manolis", status: "offline", untouchable: "true" },
+    { nodes: "node20", alerts: 15, user: "achile", status: "stale", untouchable: "true" },
+    { nodes: "node21", alerts: 11, user: "barba", status: "stale", untouchable: "false" },
+    { nodes: "node22", alerts: 22, user: "decker", status: "online", untouchable: "false" },
+    { nodes: "node23", alerts: 11, user: "koukouroukou", status: "offline", untouchable: "true" },
+    { nodes: "node24", alerts: 22, user: "reena", status: "online", untouchable: "true" },
+    { nodes: "node25", alerts: 15, user: "nic", status: "online", untouchable: "true" },
+    { nodes: "node26", alerts: 11, user: "alex", status: "offline", untouchable: "true" },
+    { nodes: "node27", alerts: 22, user: "manolis", status: "offline", untouchable: "true" },
+    { nodes: "node28", alerts: 15, user: "achile", status: "stale", untouchable: "true" },
+    { nodes: "node29", alerts: 11, user: "barba", status: "stale", untouchable: "false" },
+    { nodes: "node30", alerts: 22, user: "decker", status: "online", untouchable: "false" },
+  ]
+
+  const handleDelete = data => {
+    console.log("Delete has been clicked", data)
+  }
+
+  const rowActions = {
+    delete: {
+      handleAction: handleDelete,
+      isDisabled: row => row.disabled,
+    },
+  }
+
+  const columnPinning = { left: ["nodes"], right: ["actions"] }
+
+  return (
+    <Box height="800px" width="1000px">
+      <NetdataTable
+        dataColumns={mockDataColumns}
+        data={mockData()}
+        rowActions={rowActions}
+        columnPinning={columnPinning}
+        enableColumnPinning={true}
+        enablePinning={true}
+      />
+    </Box>
+  )
+})

--- a/src/components/tableV2/netdataTable.stories.js
+++ b/src/components/tableV2/netdataTable.stories.js
@@ -532,7 +532,14 @@ tableStories.add("With Pinning", () => {
       status: "stale",
       untouchable: "true",
     },
-    { nodes: "node0", alerts: 11, user: "koukouroukou", status: "offline", untouchable: "true" },
+    {
+      nodes:
+        "node0, node0, node0, node0, node0, node0, node0, node0, node0, node0, node0, node0, node0, node0, node0, node0",
+      alerts: 11,
+      user: "koukouroukou, koukouroukou, koukouroukou, koukouroukou",
+      status: "offline",
+      untouchable: "true",
+    },
     { nodes: "node1", alerts: 22, user: "reena", status: "online", untouchable: "true" },
     { nodes: "node1", alerts: 15, user: "nic", status: "online", untouchable: "true" },
     { nodes: "node2", alerts: 11, user: "alex", status: "offline", untouchable: "true" },
@@ -540,7 +547,7 @@ tableStories.add("With Pinning", () => {
     { nodes: "node4", alerts: 15, user: "achile", status: "stale", untouchable: "true" },
     { nodes: "node5", alerts: 11, user: "barba", status: "stale", untouchable: "false" },
     { nodes: "node6", alerts: 22, user: "decker", status: "online", untouchable: "false" },
-    { nodes: "node7", alerts: 11, user: "koukouroukou, koukouroukou, koukouroukou, koukouroukou, koukouroukou", status: "offline", untouchable: "true" },
+    { nodes: "node7", alerts: 11, user: "koukouroukou", status: "offline", untouchable: "true" },
     { nodes: "node8", alerts: 22, user: "reena", status: "online", untouchable: "true" },
     { nodes: "node9", alerts: 15, user: "nic", status: "online", untouchable: "true" },
     { nodes: "node10", alerts: 11, user: "alex", status: "offline", untouchable: "true" },
@@ -580,7 +587,7 @@ tableStories.add("With Pinning", () => {
   const columnPinning = { left: ["nodes"], right: ["actions"] }
 
   return (
-    <Box height="800px" width="1000px">
+    <Box height="500px" width="1000px">
       <NetdataTable
         dataColumns={mockDataColumns}
         data={mockData()}


### PR DESCRIPTION
This PR adds the ability to define right-pinned columns in NetdataTable component.

```
const columnPinning = { right: ["actions"] }
```

It also handles the rows heights and syncs the pinned columns height with the respective table row (if they differ)