### PR TITLE
Remove defaultProps syntax from functional components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "netdata UI kit",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -8,11 +8,11 @@ export const Button = forwardRef(
   (
     {
       label,
-      icon,
+      icon = null,
       flavour,
       isLoading,
       loadingLabel,
-      onClick,
+      onClick = () => {},
       textTransform = "firstLetter",
       iconColor,
       iconSize,
@@ -52,8 +52,3 @@ export const Button = forwardRef(
     </StyledButton>
   )
 )
-
-Button.defaultProps = {
-  onClick: () => {},
-  icon: null,
-}

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -12,7 +12,7 @@ export const Checkbox = forwardRef(
       disabled,
       iconProps,
       indeterminate,
-      Label,
+      Label = Text,
       label,
       labelProps,
       labelPosition = "left",
@@ -73,8 +73,3 @@ export const Checkbox = forwardRef(
     )
   }
 )
-
-Checkbox.defaultProps = {
-  Label: Text,
-  labelPosition: "right",
-}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -40,253 +40,12 @@ const filterFns = {
   select,
 }
 
-const Table = memo(
-  forwardRef(
-    (
-      {
-        bulkActions,
-        headerChildren,
-
-        data,
-        dataColumns,
-        dataGa,
-        enableColumnPinning,
-        columnPinning: defaultColumnPinning,
-        onColumnPinningChange: pinningChangeCb,
-
-        enableColumnVisibility,
-        columnVisibility: defaultColumnVisibility,
-        onColumnVisibilityChange: visibilityChangeCb,
-
-        enableColumnSizing,
-        columnSizing: defaultColumnSizing,
-        onColumnSizingChange: sizingChangeCb,
-
-        enablePagination,
-        enableResizing,
-        enableSelection,
-        enableSubRowSelection,
-        rowSelection: defaultRowSelection,
-        onRowSelectionChange: rowSelectionChangeCb,
-
-        expanded: defaultExpanded,
-        onExpandedChange: expandedChangeCb,
-
-        enableSorting,
-        sortBy,
-        onSortingChange: sortingChangeCb,
-
-        globalFilter: defaultGlobalFilter,
-        onSearch,
-        globalFilterFn = includesString,
-        enableCustomSearch,
-
-        grouping: defaultGrouping,
-        onGroupByChange: groupingChangeCb,
-        groupByColumns,
-
-        onRowSelected,
-
-        paginationOptions,
-        onPaginationChange: paginationChangeCb,
-
-        rowActions,
-        testPrefix,
-        meta: tableMeta,
-        title,
-        virtualizeOptions,
-        tableRef,
-        className,
-        width,
-        ...rest
-      },
-      ref
-    ) => {
-      const [columnVisibility, onColumnVisibilityChange] = useVisibility(
-        defaultColumnVisibility,
-        visibilityChangeCb
-      )
-
-      const [columnSizing, onColumnSizingChange] = useSizing(defaultColumnSizing, sizingChangeCb)
-
-      const [columnPinning, onColumnPinningChange] = usePinning(
-        defaultColumnPinning,
-        pinningChangeCb
-      )
-
-      const [expanded, onExpandedChange] = useExpanding(defaultExpanded, expandedChangeCb)
-
-      const [rowSelection, onRowSelectionChange] = useSelecting(
-        defaultRowSelection,
-        rowSelectionChangeCb
-      )
-
-      const [sorting, onSortingChange] = useSorting(sortBy, sortingChangeCb)
-
-      const [pagination, onPaginationChange] = usePaginating(paginationOptions, paginationChangeCb)
-
-      const [grouping, onGroupingChange] = useGrouping(defaultGrouping, groupingChangeCb)
-
-      const [globalFilter, onGlobalFilterChange] = useSearching(defaultGlobalFilter, onSearch)
-
-      const columns = useColumns(dataColumns, {
-        testPrefix,
-        enableSelection,
-        enableResizing,
-        enableSorting,
-        rowActions,
-        tableMeta,
-      })
-
-      const table = useReactTable({
-        columns,
-        data,
-        manualPagination: !enablePagination,
-        columnResizeMode: "onEnd",
-        filterFns,
-        state: {
-          columnVisibility,
-          columnSizing,
-          rowSelection,
-          globalFilter: enableCustomSearch ? "" : globalFilter,
-          sorting,
-          pagination,
-          columnPinning,
-          expanded,
-          grouping: useMemo(
-            () =>
-              Array.isArray(grouping)
-                ? [grouping].filter(Boolean)
-                : groupByColumns?.[grouping]?.columns || [],
-            [grouping]
-          ),
-          columnOrder: [],
-        },
-        onExpandedChange,
-        ...(!enableCustomSearch && globalFilterFn ? { globalFilterFn } : {}),
-        getCoreRowModel: getCoreRowModel(),
-        getFilteredRowModel: getFilteredRowModel(),
-        onRowSelectionChange,
-        onGlobalFilterChange: enableCustomSearch ? undefined : onGlobalFilterChange,
-        onSortingChange,
-        getSortedRowModel: getSortedRowModel(),
-        getPaginationRowModel: getPaginationRowModel(),
-        getExpandedRowModel: getExpandedRowModel(),
-        getGroupedRowModel: getGroupedRowModel(),
-        getSubRows: useCallback(row => row.children, []),
-        onPaginationChange,
-        onColumnVisibilityChange,
-        onColumnSizingChange,
-        onColumnPinningChange,
-        enableSubRowSelection,
-        columnGroupingMode: "reorder",
-      })
-
-      const prevStateRef = useRef(table.getState())
-      table.isEqual = (selector = identity) => {
-        if (!prevStateRef.current) {
-          prevStateRef.current = table.getState()
-          return false
-        }
-
-        const areStatesEqual = isEqual(selector(prevStateRef.current), selector(table.getState()))
-
-        prevStateRef.current = table.getState()
-        return areStatesEqual
-      }
-
-      const dispatch = useTableDispatch()
-
-      const dispatchThrottled = useCallback(throttle(10, dispatch), [])
-
-      useLayoutEffect(() => {
-        dispatchThrottled({
-          ...table.getState(),
-          rowsById: table.getRowModel().rowsById,
-          table,
-          selectedRows: table.getSelectedRowModel().flatRows,
-        })
-      }, [table.getState()])
-
-      if (tableRef) tableRef.current = table
-
-      const { getHasNextPage, loading, warning } = virtualizeOptions
-
-      return (
-        <Flex
-          height={{ max: "100%" }}
-          overflow="hidden"
-          column
-          flex="1"
-          ref={ref}
-          className={className}
-          width={width}
-        >
-          <Header
-            q={globalFilter}
-            hasSearch={!!onSearch}
-            onSearch={onGlobalFilterChange}
-            groupByColumns={groupByColumns}
-            onGroupBy={onGroupingChange}
-            grouping={grouping}
-            tableMeta={tableMeta}
-            title={title}
-            dataColumns={dataColumns}
-            enableColumnVisibility={enableColumnVisibility}
-            bulkActions={bulkActions}
-          >
-            {headerChildren || null}
-            <HeaderActions
-              rowSelection={rowSelection}
-              bulkActions={bulkActions}
-              columnPinning={columnPinning}
-              dataGa={dataGa}
-              enableColumnVisibility={enableColumnVisibility}
-              enableColumnPinning={enableColumnPinning}
-              table={table}
-              testPrefix={testPrefix}
-              onRowSelected={onRowSelected}
-            />
-          </Header>
-          <Body
-            table={table}
-            dataGa={dataGa}
-            testPrefix={testPrefix}
-            meta={tableMeta}
-            {...rest}
-            {...virtualizeOptions}
-          />
-          {!getHasNextPage?.() && !loading && !!warning && (
-            <Flex alignItems="center" justifyContent="center" gap={2} padding={[4]} width="100%">
-              <Icon name="warning_triangle_hollow" color="warning" />{" "}
-              <Text color="warningText">{warning}</Text>
-            </Flex>
-          )}
-          {loading && (
-            <Layer
-              backdrop={false}
-              position="bottom"
-              margin={[0, 0, 10]}
-              padding={[0, 0, 10]}
-              zIndex={20}
-            >
-              <Flex background="tooltip" padding={[1, 2]} gap={2}>
-                <Text strong>Loading more...</Text>
-              </Flex>
-            </Layer>
-          )}
-          {enablePagination && <Pagination table={table} />}
-        </Flex>
-      )
-    }
-  )
-)
-
-Table.defaultProps = {
+const tableDefaultProps = {
   coloredSortedColumn: true,
   enableColumnPinning: false,
   enableColumnVisibility: false,
   enableResizing: false,
+  globalFilterFn: includesString,
   onColumnVisibilityChange: noop,
   onSortingChange: noop,
   onExpandedChange: noop,
@@ -302,6 +61,242 @@ Table.defaultProps = {
   testPrefix: "",
   virtualizeOptions: {},
 }
+
+const Table = memo(
+  forwardRef((props, ref) => {
+    const {
+      bulkActions,
+      headerChildren,
+
+      data,
+      dataColumns,
+      dataGa,
+      enableColumnPinning,
+      columnPinning: defaultColumnPinning,
+      onColumnPinningChange: pinningChangeCb,
+
+      enableColumnVisibility,
+      columnVisibility: defaultColumnVisibility,
+      onColumnVisibilityChange: visibilityChangeCb,
+
+      enableColumnSizing,
+      columnSizing: defaultColumnSizing,
+      onColumnSizingChange: sizingChangeCb,
+
+      enablePagination,
+      enableResizing,
+      enableSelection,
+      enableSubRowSelection,
+      rowSelection: defaultRowSelection,
+      onRowSelectionChange: rowSelectionChangeCb,
+
+      expanded: defaultExpanded,
+      onExpandedChange: expandedChangeCb,
+
+      enableSorting,
+      sortBy,
+      onSortingChange: sortingChangeCb,
+
+      globalFilter: defaultGlobalFilter,
+      onSearch,
+      globalFilterFn,
+      enableCustomSearch,
+
+      grouping: defaultGrouping,
+      onGroupByChange: groupingChangeCb,
+      groupByColumns,
+
+      onRowSelected,
+
+      paginationOptions,
+      onPaginationChange: paginationChangeCb,
+
+      rowActions,
+      testPrefix,
+      meta: tableMeta,
+      title,
+      virtualizeOptions,
+      tableRef,
+      className,
+      width,
+      ...rest
+    } = { ...tableDefaultProps, ...props }
+
+    const [columnVisibility, onColumnVisibilityChange] = useVisibility(
+      defaultColumnVisibility,
+      visibilityChangeCb
+    )
+
+    const [columnSizing, onColumnSizingChange] = useSizing(defaultColumnSizing, sizingChangeCb)
+
+    const [columnPinning, onColumnPinningChange] = usePinning(defaultColumnPinning, pinningChangeCb)
+
+    const [expanded, onExpandedChange] = useExpanding(defaultExpanded, expandedChangeCb)
+
+    const [rowSelection, onRowSelectionChange] = useSelecting(
+      defaultRowSelection,
+      rowSelectionChangeCb
+    )
+
+    const [sorting, onSortingChange] = useSorting(sortBy, sortingChangeCb)
+
+    const [pagination, onPaginationChange] = usePaginating(paginationOptions, paginationChangeCb)
+
+    const [grouping, onGroupingChange] = useGrouping(defaultGrouping, groupingChangeCb)
+
+    const [globalFilter, onGlobalFilterChange] = useSearching(defaultGlobalFilter, onSearch)
+
+    const columns = useColumns(dataColumns, {
+      testPrefix,
+      enableSelection,
+      enableResizing,
+      enableSorting,
+      rowActions,
+      tableMeta,
+    })
+
+    const table = useReactTable({
+      columns,
+      data,
+      manualPagination: !enablePagination,
+      columnResizeMode: "onEnd",
+      filterFns,
+      state: {
+        columnVisibility,
+        columnSizing,
+        rowSelection,
+        globalFilter: enableCustomSearch ? "" : globalFilter,
+        sorting,
+        pagination,
+        columnPinning,
+        expanded,
+        grouping: useMemo(
+          () =>
+            Array.isArray(grouping)
+              ? [grouping].filter(Boolean)
+              : groupByColumns?.[grouping]?.columns || [],
+          [grouping]
+        ),
+        columnOrder: [],
+      },
+      onExpandedChange,
+      ...(!enableCustomSearch && globalFilterFn ? { globalFilterFn } : {}),
+      getCoreRowModel: getCoreRowModel(),
+      getFilteredRowModel: getFilteredRowModel(),
+      onRowSelectionChange,
+      onGlobalFilterChange: enableCustomSearch ? undefined : onGlobalFilterChange,
+      onSortingChange,
+      getSortedRowModel: getSortedRowModel(),
+      getPaginationRowModel: getPaginationRowModel(),
+      getExpandedRowModel: getExpandedRowModel(),
+      getGroupedRowModel: getGroupedRowModel(),
+      getSubRows: useCallback(row => row.children, []),
+      onPaginationChange,
+      onColumnVisibilityChange,
+      onColumnSizingChange,
+      onColumnPinningChange,
+      enableSubRowSelection,
+      columnGroupingMode: "reorder",
+    })
+
+    const prevStateRef = useRef(table.getState())
+    table.isEqual = (selector = identity) => {
+      if (!prevStateRef.current) {
+        prevStateRef.current = table.getState()
+        return false
+      }
+
+      const areStatesEqual = isEqual(selector(prevStateRef.current), selector(table.getState()))
+
+      prevStateRef.current = table.getState()
+      return areStatesEqual
+    }
+
+    const dispatch = useTableDispatch()
+
+    const dispatchThrottled = useCallback(throttle(10, dispatch), [])
+
+    useLayoutEffect(() => {
+      dispatchThrottled({
+        ...table.getState(),
+        rowsById: table.getRowModel().rowsById,
+        table,
+        selectedRows: table.getSelectedRowModel().rows,
+      })
+    }, [table.getState()])
+
+    if (tableRef) tableRef.current = table
+
+    const { getHasNextPage, loading, warning } = virtualizeOptions
+
+    return (
+      <Flex
+        height={{ max: "100%" }}
+        overflow="hidden"
+        column
+        flex="1"
+        ref={ref}
+        className={className}
+        width={width}
+      >
+        <Header
+          q={globalFilter}
+          hasSearch={!!onSearch}
+          onSearch={onGlobalFilterChange}
+          groupByColumns={groupByColumns}
+          onGroupBy={onGroupingChange}
+          grouping={grouping}
+          tableMeta={tableMeta}
+          title={title}
+          dataColumns={dataColumns}
+          enableColumnVisibility={enableColumnVisibility}
+          bulkActions={bulkActions}
+        >
+          {headerChildren || null}
+          <HeaderActions
+            rowSelection={rowSelection}
+            bulkActions={bulkActions}
+            columnPinning={columnPinning}
+            dataGa={dataGa}
+            enableColumnVisibility={enableColumnVisibility}
+            enableColumnPinning={enableColumnPinning}
+            table={table}
+            testPrefix={testPrefix}
+            onRowSelected={onRowSelected}
+          />
+        </Header>
+        <Body
+          table={table}
+          dataGa={dataGa}
+          testPrefix={testPrefix}
+          meta={tableMeta}
+          {...rest}
+          {...virtualizeOptions}
+        />
+        {!getHasNextPage?.() && !loading && !!warning && (
+          <Flex alignItems="center" justifyContent="center" gap={2} padding={[4]} width="100%">
+            <Icon name="warning_triangle_hollow" color="warning" />{" "}
+            <Text color="warningText">{warning}</Text>
+          </Flex>
+        )}
+        {loading && (
+          <Layer
+            backdrop={false}
+            position="bottom"
+            margin={[0, 0, 10]}
+            padding={[0, 0, 10]}
+            zIndex={20}
+          >
+            <Flex background="tooltip" padding={[1, 2]} gap={2}>
+              <Text strong>Loading more...</Text>
+            </Flex>
+          </Layer>
+        )}
+        {enablePagination && <Pagination table={table} />}
+      </Flex>
+    )
+  })
+)
 
 const withProvider = Component =>
   forwardRef((props, ref) => {

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -8,8 +8,8 @@ export const Toggle = ({
   className,
   labelLeft,
   labelRight,
-  Label,
-  colored,
+  Label = Text,
+  colored = false,
   margin,
   alignSelf,
   toggleProps = {},
@@ -23,7 +23,13 @@ export const Toggle = ({
     )}
     <ToggleContainer>
       <HiddenToggleInput disabled={disabled} checked={checked} {...props} />
-      <StyledToggle checked={checked} disabled={disabled} colored={colored} role="switch" {...toggleProps} />
+      <StyledToggle
+        checked={checked}
+        disabled={disabled}
+        colored={colored}
+        role="switch"
+        {...toggleProps}
+      />
     </ToggleContainer>
     {labelRight && (
       <LabelText as={Label} right>
@@ -32,8 +38,3 @@ export const Toggle = ({
     )}
   </StyledLabel>
 )
-
-Toggle.defaultProps = {
-  colored: false,
-  Label: Text,
-}


### PR DESCRIPTION
React is going to deprecate `defaultProps` from functional components in future (throws warning on console now)
https://github.com/facebook/react/pull/16210