### PR TITLE
Fix memoized table object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "4.8.14",
+  "version": "4.8.15",
   "description": "netdata UI kit",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",

--- a/src/components/table/body/header/index.js
+++ b/src/components/table/body/header/index.js
@@ -4,13 +4,18 @@ import { useTableState } from "../../provider"
 import Cell from "./cell"
 
 const rerenderSelector = state => {
+  const columns = state.table?.getAllColumns() || []
+
   return {
     sizing: state.columnSizing,
     expanded: state.expanded,
     columnVisibility: state.columnVisibility,
     selectedRows: state.selectedRows,
     grouping: state.grouping,
-    columnsCount: state.table && state.table.getAllColumns().length,
+    columnsCount: columns.length,
+    columnsFilters: columns.map(({ columnDef }) => ({
+      filterOptions: columnDef?.meta?.filter?.options,
+    })),
   }
 }
 

--- a/src/components/table/body/header/index.js
+++ b/src/components/table/body/header/index.js
@@ -4,7 +4,7 @@ import { useTableState } from "../../provider"
 import Cell from "./cell"
 
 const rerenderSelector = state => {
-  const columns = state.table?.getAllColumns() || []
+  const columns = state.table?.getAllColumns?.() || []
 
   return {
     sizing: state.columnSizing,
@@ -13,9 +13,7 @@ const rerenderSelector = state => {
     selectedRows: state.selectedRows,
     grouping: state.grouping,
     columnsCount: columns.length,
-    columnsFilters: columns.map(({ columnDef }) => ({
-      filterOptions: columnDef?.meta?.filter?.options,
-    })),
+    columnsFilters: columns.map(({ columnDef }) => columnDef?.meta?.filter?.options),
   }
 }
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -156,7 +156,7 @@ const Table = memo(
       tableMeta,
     })
 
-    const table = useReactTable({
+    const reactTable = useReactTable({
       columns,
       data,
       manualPagination: !enablePagination,
@@ -202,6 +202,9 @@ const Table = memo(
       enableSubRowSelection,
       columnGroupingMode: "reorder",
     })
+
+    // Add timestamp to distinguish different versions of the object and correctly render memoized components
+    const table = { ...reactTable, timestamp: Date.now() }
 
     const prevStateRef = useRef(table.getState())
     table.isEqual = (selector = identity) => {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -156,7 +156,7 @@ const Table = memo(
       tableMeta,
     })
 
-    const reactTable = useReactTable({
+    const table = useReactTable({
       columns,
       data,
       manualPagination: !enablePagination,
@@ -202,9 +202,6 @@ const Table = memo(
       enableSubRowSelection,
       columnGroupingMode: "reorder",
     })
-
-    // Add timestamp to distinguish different versions of the object and correctly render memoized components
-    const table = { ...reactTable, timestamp: Date.now() }
 
     const prevStateRef = useRef(table.getState())
     table.isEqual = (selector = identity) => {


### PR DESCRIPTION
When we pass a value to `dataColumns` prop of the `Table` component, that changes over re-renders, `BodyHeader` component cannot distinguish between different versions of `table` object and keeps the first version of it.

~By adding `timestamp` prop to `table` object each time we create it, we ensure that `memo` recognizes each version and re-renders `BodyHeader` component to reflect latest state.~