### PR TITLE
v5.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/netdata-ui",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "netdata UI kit",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",

--- a/src/components/icon/assets/integrations/group_email_colored.svg
+++ b/src/components/icon/assets/integrations/group_email_colored.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17.891 3H6.108C3.287 3 1 5.287 1 8.108V15.891C1 18.713 3.287 21 6.109 21H17.892C20.713 21 23 18.713 23 15.892V8.108C23 5.287 20.713 3 17.891 3Z" fill="#49B5E6" />
+  <path transform="translate(3.84 3.84) scale(0.68)" d="M22 6V4l-8 5l-8-5v2l8 5zm0-4a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4c0-1.11.89-2 2-2zM2 6v14h18v2H2a2 2 0 0 1-2-2V6z" fill="white" />
+</svg>

--- a/src/components/icon/iconsList.js
+++ b/src/components/icon/iconsList.js
@@ -149,6 +149,7 @@ import integrationDiscord from "./assets/integrations/discord.svg"
 import integrationDiscordColored from "./assets/integrations/discord_colored.svg"
 import integrationEmail from "./assets/integrations/email.svg"
 import integrationEmailColored from "./assets/integrations/email_colored.svg"
+import integrationGroupEmailColored from "./assets/integrations/group_email_colored.svg"
 import integrationIlert from "./assets/integrations/ilert.svg"
 import integrationIlertColored from "./assets/integrations/ilert_colored.svg"
 import integrationJiraColored from "./assets/integrations/jira_colored.svg"
@@ -628,6 +629,7 @@ export const iconsList = {
   integrationDiscordColored,
   integrationEmail,
   integrationEmailColored,
+  integrationGroupEmailColored,
   integrationIlert,
   integrationIlertColored,
   integrationJiraColored,


### PR DESCRIPTION
Adds the `group_email_colored` SVG asset under `src/components/icon/assets/integrations/` and registers it as `integrationGroupEmailColored` in `iconsList.js` so it is available through the `Icon` component.